### PR TITLE
Send public content to the relay system

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -266,6 +266,8 @@ SOCIALHOME_URL = "{protocol}://{domain}".format(
     protocol="https" if SOCIALHOME_HTTPS else "http",
     domain=SOCIALHOME_DOMAIN
 )
+# Relay to send public content to
+SOCIALHOME_RELAY_DOMAIN = env("SOCIALHOME_RELAY_DOMAIN", default="relay.iliketoast.net")
 
 
 # REDIS

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -43,16 +43,17 @@ MIDDLEWARE_CLASSES = PRODUCTION_MIDDLEWARE + MIDDLEWARE_CLASSES
 
 # opbeat integration
 # See https://opbeat.com/languages/django/
-# TODO enable once in ansible role
-# INSTALLED_APPS += ('opbeat.contrib.django',)
-# OPBEAT = {
-#     'ORGANIZATION_ID': env('DJANGO_OPBEAT_ORGANIZATION_ID'),
-#     'APP_ID': env('DJANGO_OPBEAT_APP_ID'),
-#     'SECRET_TOKEN': env('DJANGO_OPBEAT_SECRET_TOKEN')
-# }
-# MIDDLEWARE_CLASSES = (
-#     'opbeat.contrib.django.middleware.OpbeatAPMMiddleware',
-# ) + MIDDLEWARE_CLASSES
+OPBEAT_ENABLE = env("DJANGO_OPBEAT_ENABLE", default=False)
+if OPBEAT_ENABLE:
+    INSTALLED_APPS += ('opbeat.contrib.django',)
+    OPBEAT = {
+        'ORGANIZATION_ID': env('DJANGO_OPBEAT_ORGANIZATION_ID'),
+        'APP_ID': env('DJANGO_OPBEAT_APP_ID'),
+        'SECRET_TOKEN': env('DJANGO_OPBEAT_SECRET_TOKEN')
+    }
+    MIDDLEWARE_CLASSES = (
+        'opbeat.contrib.django.middleware.OpbeatAPMMiddleware',
+    ) + MIDDLEWARE_CLASSES
 
 # STORAGE CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -114,11 +114,6 @@ CACHES = {
 # LOGGING CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#logging
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
-# See http://docs.djangoproject.com/en/dev/topics/logging for
-# more details on how to customize your logging configuration.
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -163,13 +158,13 @@ LOGGING = {
     },
     'loggers': {
         'django.request': {
-            'handlers': ['mail_admins'],
+            'handlers': ['application_file'],
             'level': 'ERROR',
             'propagate': True
         },
         'django.security.DisallowedHost': {
             'level': 'ERROR',
-            'handlers': ['console', 'mail_admins'],
+            'handlers': ['console', 'application_file'],
             'propagate': True
         },
         "socialhome": {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ celery==3.1.23
 django-extensions==1.6.7
 
 # Federation
-Social-Federation==0.4.0
+Social-Federation==0.4.1
 
 # Content
 django-markdownx==1.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ celery==3.1.23
 django-extensions==1.6.7
 
 # Federation
-Social-Federation==0.4.1
+Social-Federation==0.5.0
 
 # Content
 django-markdownx==1.6

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -59,6 +59,18 @@ class Content(models.Model):
     def is_nsfw(self):
         return self.text.lower().find("#nsfw") > -1
 
+    @property
+    def is_local(self):
+        if self.author.user:
+            return True
+        return False
+
+    @property
+    def effective_created(self):
+        if self.remote_created:
+            return self.remote_created
+        return self.created
+
     def render(self):
         rendered = markdownify(self.text)
         if self.is_nsfw:

--- a/socialhome/content/signals.py
+++ b/socialhome/content/signals.py
@@ -1,11 +1,15 @@
 import json
+import logging
 
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from socialhome.content.models import Content
 from socialhome.enums import Visibility
+from socialhome.federate.tasks import send_content
 from socialhome.streams.consumers import StreamConsumer
+
+logger = logging.getLogger("socialhome")
 
 
 @receiver(post_save, sender=Content)
@@ -17,3 +21,17 @@ def notify_listeners(sender, **kwargs):
                 "event": "new",
                 "id": content.id,
             }))
+
+
+@receiver(post_save, sender=Content)
+def federate_content(sender, **kwargs):
+    """Send out local content to the federation layer.
+
+    Yes, edits also. The federation layer should decide whether these are really worth sending out.
+    """
+    content = kwargs.get("instance")
+    if content.is_local:
+        try:
+            send_content.delay(content)
+        except Exception as ex:
+            logger.exception("Failed to federate_content %s: %s", content, ex)

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -104,3 +104,10 @@ class TestContentModel(TestCase):
         self.assertEqual(mock_clear.call_args_list, [
             call(self.public_content, "is_nsfw"), call(self.public_content, "rendered")
         ])
+
+    def test_is_local(self):
+        self.assertFalse(self.public_content.is_local)
+        user = self.make_user()
+        user.profile = self.public_content.author
+        user.save()
+        self.assertTrue(self.public_content.is_local)

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import datetime
 from unittest.mock import Mock, patch, call
 
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, transaction
+from django.utils.timezone import make_aware
 from test_plus import TestCase
 
 from socialhome.content.models import Content
@@ -25,6 +27,9 @@ class TestContentModel(TestCase):
         )
         cls.limited_content = ContentFactory(visibility=Visibility.LIMITED)
         cls.self_content = ContentFactory(visibility=Visibility.SELF)
+        cls.remote_content = ContentFactory(
+            visibility=Visibility.PUBLIC, remote_created=make_aware(datetime.datetime(2015, 1, 1))
+        )
         cls.ids = [
             cls.public_content.id, cls.site_content.id, cls.limited_content.id, cls.self_content.id
         ]
@@ -111,3 +116,23 @@ class TestContentModel(TestCase):
         user.profile = self.public_content.author
         user.save()
         self.assertTrue(self.public_content.is_local)
+
+    def test_save_calls_fix_local_uploads(self):
+        self.public_content.fix_local_uploads = Mock()
+        self.public_content.save()
+        self.public_content.fix_local_uploads.assert_called_once_with()
+
+    def test_fix_local_uploads(self):
+        self.public_content.text = "foobar ![](/media/markdownx/12345.jpg) barfoo"
+        self.public_content.save()
+        self.public_content.refresh_from_db()
+        self.assertEqual(
+            self.public_content.text,
+            "foobar ![](http://127.0.0.1:8000/media/markdownx/12345.jpg) barfoo"
+        )
+
+    def test_effective_created(self):
+        self.assertEqual(self.public_content.effective_created, self.public_content.created)
+        self.assertIsNone(self.public_content.remote_created)
+        self.assertEqual(self.remote_content.effective_created, self.remote_content.remote_created)
+        self.assertIsNotNone(self.remote_content.remote_created)

--- a/socialhome/content/tests/test_signals.py
+++ b/socialhome/content/tests/test_signals.py
@@ -5,10 +5,11 @@ import pytest
 from test_plus import TestCase
 
 from socialhome.content.tests.factories import ContentFactory
+from socialhome.users.tests.factories import UserFactory
 
 
 @pytest.mark.usefixtures("db")
-class TestContentModel(TestCase):
+class TestNotifyListeners(TestCase):
     @patch("socialhome.content.signals.StreamConsumer")
     def test_content_save_calls_streamconsumer_group_send(self, mock_consumer):
         mock_consumer.group_send = Mock()
@@ -21,3 +22,17 @@ class TestContentModel(TestCase):
         content.text = "foo"
         content.save()
         self.assertFalse(mock_consumer.group_send.called)
+
+
+@pytest.mark.usefixtures("db")
+@patch("socialhome.content.signals.send_content.delay")
+class TestFederateContent(TestCase):
+    def test_non_local_content_does_not_get_sent(self, mock_send):
+        ContentFactory()
+        mock_send.assert_not_called()
+
+    def test_local_content_gets_sent(self, mock_send):
+        user = UserFactory()
+        content = ContentFactory(author=user.profile)
+        self.assertTrue(content.is_local)
+        mock_send.assert_called_once_with(content)

--- a/socialhome/content/tests/test_signals.py
+++ b/socialhome/content/tests/test_signals.py
@@ -25,14 +25,22 @@ class TestNotifyListeners(TestCase):
 
 
 @pytest.mark.usefixtures("db")
-@patch("socialhome.content.signals.send_content.delay")
 class TestFederateContent(TestCase):
+    @patch("socialhome.content.signals.send_content.delay")
     def test_non_local_content_does_not_get_sent(self, mock_send):
         ContentFactory()
         mock_send.assert_not_called()
 
+    @patch("socialhome.content.signals.send_content.delay")
     def test_local_content_gets_sent(self, mock_send):
         user = UserFactory()
         content = ContentFactory(author=user.profile)
         self.assertTrue(content.is_local)
         mock_send.assert_called_once_with(content)
+
+    @patch("socialhome.content.signals.send_content.delay", side_effect=Exception)
+    @patch("socialhome.content.signals.logger.exception")
+    def test_exception_calls_logger(self, mock_logger, mock_send):
+        user = UserFactory()
+        ContentFactory(author=user.profile)
+        self.assertTrue(mock_logger.called)

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -62,7 +62,7 @@ def send_content(content):
         # Just dump to the relay system for now
         # TODO: implement send_document helper in Social-Federation
         url = "https://%s/receive/public" % settings.SOCIALHOME_RELAY_DOMAIN
-        logger.debug("Sending document to %s: %s", url, paylod)
+        logger.debug("Sending document to %s: %s", url, payload)
         try:
             response = requests.post(url, payload, headers={'user-agent': "socialhome/0.1"})
             logger.debug("Response: %s", response)

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from federation.exceptions import NoSuitableProtocolFoundError
 from federation.inbound import handle_receive
 from federation.outbound import handle_create_payload
+from federation.utils.network import send_document
 
 from socialhome.enums import Visibility
 from socialhome.federate.utils.tasks import get_sender_profile, process_entities, make_federable_entity
@@ -46,27 +47,16 @@ def send_content(content):
     """Handle sending a Content object out via the federation layer.
 
     Currently we only deliver public content.
-
-    TODO: parts of this should really be in Social-Federation. We should be able to just
-    convert our Content to Social-Federation entities and call a simple send method that just works.
     """
     if not content.visibility == Visibility.PUBLIC:
         return
-    # TODO: Social-Federation requires changing to not require a `to_user` on public content
-    # Use a mock contact object for now
-    class MockContact(object):
-        key = None
     entity = make_federable_entity(content)
     if entity:
-        payload = handle_create_payload(content.author, MockContact(), entity)
+        # TODO: Social-Federation should provide one method to send,
+        # which handles also payload creation and url calculation
+        payload = handle_create_payload(entity, content.author)
         # Just dump to the relay system for now
-        # TODO: implement send_document helper in Social-Federation
         url = "https://%s/receive/public" % settings.SOCIALHOME_RELAY_DOMAIN
-        logger.debug("Sending document to %s: %s", url, payload)
-        try:
-            response = requests.post(url, payload, headers={'user-agent': "socialhome/0.1"})
-            logger.debug("Response: %s", response)
-        except Exception as ex:
-            logger.exception("Error sending entity %s: %s", entity, ex)
+        send_document(url, payload)
     else:
-        logger.info("No entity for %s", content)
+        logger.warning("No entity for %s", content)

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -1,9 +1,14 @@
 import logging
 
+import requests
+from django.conf import settings
+
 from federation.exceptions import NoSuitableProtocolFoundError
 from federation.inbound import handle_receive
+from federation.outbound import handle_create_payload
 
-from socialhome.federate.utils.tasks import get_sender_profile, process_entities
+from socialhome.enums import Visibility
+from socialhome.federate.utils.tasks import get_sender_profile, process_entities, make_federable_entity
 from socialhome.taskapp.celery import tasks
 from socialhome.users.models import Profile
 
@@ -34,3 +39,34 @@ def receive_task(payload, guid=None):
     if not sender_profile:
         return
     process_entities(entities, profile=sender_profile)
+
+
+@tasks.task()
+def send_content(content):
+    """Handle sending a Content object out via the federation layer.
+
+    Currently we only deliver public content.
+
+    TODO: parts of this should really be in Social-Federation. We should be able to just
+    convert our Content to Social-Federation entities and call a simple send method that just works.
+    """
+    if not content.visibility == Visibility.PUBLIC:
+        return
+    # TODO: Social-Federation requires changing to not require a `to_user` on public content
+    # Use a mock contact object for now
+    class MockContact(object):
+        key = None
+    entity = make_federable_entity(content)
+    if entity:
+        payload = handle_create_payload(content.author, MockContact(), entity)
+        # Just dump to the relay system for now
+        # TODO: implement send_document helper in Social-Federation
+        url = "https://%s/receive/public" % settings.SOCIALHOME_RELAY_DOMAIN
+        logger.debug("Sending document to %s: %s", url, paylod)
+        try:
+            response = requests.post(url, payload, headers={'user-agent': "socialhome/0.1"})
+            logger.debug("Response: %s", response)
+        except Exception as ex:
+            logger.exception("Error sending entity %s: %s", entity, ex)
+    else:
+        logger.info("No entity for %s", content)

--- a/socialhome/federate/tests/test_utils_tasks.py
+++ b/socialhome/federate/tests/test_utils_tasks.py
@@ -47,8 +47,7 @@ class TestGetSenderProfile(object):
 
     @patch("socialhome.federate.utils.tasks.retrieve_remote_profile")
     def test_fetches_remote_profile_if_not_found(self, mock_retrieve):
-        # TODO: use ProfileFactory from Social-Federation once available
-        mock_retrieve.return_value = base.Profile(
+        mock_retrieve.return_value = entities.ProfileFactory(
             name="foobar", raw_content="barfoo", public_key="xyz",
             handle="foo@example.com", guid="123456"
         )
@@ -68,8 +67,7 @@ class TestGetSenderProfile(object):
 
     @patch("socialhome.federate.utils.tasks.retrieve_remote_profile")
     def test_cleans_text_fields_in_profile(self, mock_retrieve):
-        # TODO: use ProfileFactory from Social-Federation once available
-        mock_retrieve.return_value = base.Profile(
+        mock_retrieve.return_value = entities.ProfileFactory(
             name="<script>alert('yup');</script>", raw_content="<script>alert('yup');</script>",
             public_key="<script>alert('yup');</script>",
             handle="foo@example.com", guid="<script>alert('yup');</script>",

--- a/socialhome/federate/urls.py
+++ b/socialhome/federate/urls.py
@@ -6,7 +6,7 @@ from federation.hostmeta.generators import NODEINFO_DOCUMENT_PATH
 
 from socialhome.federate.views import (
     host_meta_view, webfinger_view, hcard_view, nodeinfo_well_known_view, nodeinfo_view, social_relay_view,
-    ReceivePublicView, ReceiveUserView)
+    ReceivePublicView, ReceiveUserView, content_xml_view)
 
 
 urlpatterns = [
@@ -25,4 +25,7 @@ urlpatterns = [
     url(r"^receive/public$", csrf_exempt(ReceivePublicView.as_view())),
     url(r"^receive/users/(?P<guid>[^/]+)/$", csrf_exempt(ReceiveUserView.as_view()), name="receive-user"),
     url(r"^receive/users/(?P<guid>[^/]+)$", csrf_exempt(ReceiveUserView.as_view())),
+
+    # Content
+    url(r"^p/(?P<guid>[^/]+).xml$", content_xml_view, name="content-xml"),
 ]

--- a/socialhome/federate/utils/tasks.py
+++ b/socialhome/federate/utils/tasks.py
@@ -58,3 +58,20 @@ def process_entities(entities, profile):
                     logger.info("Updated Content: %s" % content)
             except Exception as ex:
                 logger.exception("Failed to handle %s: %s" % (entity.guid, ex))
+
+
+def make_federable_entity(content):
+    """Make Content federable by converting it to a Social-Federation entity."""
+    logging.info("make_federable_entity - Content: %s" % content)
+    try:
+        return base.Post(
+            raw_content=content.text,
+            guid=str(content.guid),
+            handle=content.author.handle,
+            public=True,
+            provider_display_name="Socialhome",
+            created_at=content.effective_created,
+        )
+    except Exception as ex:
+        logger.exception("make_federable_entity - Failed to convert %s: %s" % (content.guid, ex))
+        return None

--- a/socialhome/federate/views.py
+++ b/socialhome/federate/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from lxml import etree
 
 from django.conf import settings
 from django.http import HttpResponse
@@ -7,11 +8,16 @@ from django.http.response import Http404, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.views.generic import View
 
+from federation.entities.diaspora.mappers import get_outbound_entity
 from federation.hostmeta.generators import (
     generate_host_meta, generate_legacy_webfinger, generate_hcard, get_nodeinfo_well_known_document, NodeInfo,
     SocialRelayWellKnown)
+
 from socialhome import __version__ as version
+from socialhome.content.models import Content
+from socialhome.enums import Visibility
 from socialhome.federate.tasks import receive_task
+from socialhome.federate.utils.tasks import make_federable_entity
 from socialhome.users.models import User, Profile
 
 logger = logging.getLogger("socialhome")
@@ -93,6 +99,20 @@ def social_relay_view(request):
     """Generate a .well-known/x-social-relay document."""
     relay = SocialRelayWellKnown(subscribe=True)
     return JsonResponse(relay.doc)
+
+
+def content_xml_view(request, guid):
+    """Diaspora single post view XML representation.
+
+    Fetched by remote servers in certain situations.
+    """
+    # TODO push as much as we can to Social-Federation
+    content = get_object_or_404(Content, guid=guid, visibility=Visibility.PUBLIC)
+    entity = make_federable_entity(content)
+    diaspora_entity = get_outbound_entity(entity)
+    xml = diaspora_entity.to_xml()
+    document = "<XML><post>%s</post></XML>" % etree.tostring(xml).decode("utf-8")
+    return HttpResponse(document, content_type="application/xml")
 
 
 class ReceivePublicView(View):

--- a/socialhome/federate/views.py
+++ b/socialhome/federate/views.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 import logging
-from lxml import etree
 
 from django.conf import settings
 from django.http import HttpResponse
 from django.http.response import Http404, JsonResponse, HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.views.generic import View
+from lxml import etree
 
 from federation.entities.diaspora.mappers import get_outbound_entity
+from federation.entities.diaspora.utils import get_full_xml_representation
 from federation.hostmeta.generators import (
     generate_host_meta, generate_legacy_webfinger, generate_hcard, get_nodeinfo_well_known_document, NodeInfo,
     SocialRelayWellKnown)
@@ -106,13 +107,9 @@ def content_xml_view(request, guid):
 
     Fetched by remote servers in certain situations.
     """
-    # TODO push as much as we can to Social-Federation
     content = get_object_or_404(Content, guid=guid, visibility=Visibility.PUBLIC)
     entity = make_federable_entity(content)
-    diaspora_entity = get_outbound_entity(entity)
-    xml = diaspora_entity.to_xml()
-    document = "<XML><post>%s</post></XML>" % etree.tostring(xml).decode("utf-8")
-    return HttpResponse(document, content_type="application/xml")
+    return HttpResponse(get_full_xml_representation(entity), content_type="application/xml")
 
 
 class ReceivePublicView(View):

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -106,13 +106,18 @@ class Profile(models.Model):
 
     @property
     def key(self):
-        """Required by Social-Federation."""
-        return RSA.importKey(self.rsa_private_key)
+        """Required by Social-Federation.
+
+        Corresponds to public key.
+        """
+        return RSA.importKey(self.rsa_public_key)
 
     @property
     def private_key(self):
-        """Also required by Social-Federation."""
-        # TODO: make Social-Federation a bit saner here
+        """Required by Social-Federation.
+
+        Corresponds to private key.
+        """
         return RSA.importKey(self.rsa_private_key)
 
     @property

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -110,6 +110,12 @@ class Profile(models.Model):
         return RSA.importKey(self.rsa_private_key)
 
     @property
+    def private_key(self):
+        """Also required by Social-Federation."""
+        # TODO: make Social-Federation a bit saner here
+        return RSA.importKey(self.rsa_private_key)
+
+    @property
     def public(self):
         """Is this profile public or one of the more limited visibilities?"""
         return self.visibility == Visibility.PUBLIC


### PR DESCRIPTION
Any locally created (or edited) public content will be sent to the relay system.

Also:
- Bump Social-Federation
- Fix local uploads by adding the full domain to them
- Add public content XML view (needed by remotes)
- Add Opbeat configuration possibility

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jaywink/socialhome/53)

<!-- Reviewable:end -->
