### PR TITLE
Add federate.content_fetch_view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [unreleased]
 
+### Added
+* Diaspora fetch entities view is now implemented as described in [the Diaspora protocol PR](https://github.com/diaspora/diaspora_federation/issues/31).
+
 ### License change
 
 As the project is still in early changes, decision have to be made about the long term license.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ celery==3.1.23
 django-extensions==1.6.7
 
 # Federation
-Social-Federation==0.5.0
+Social-Federation==0.6.0
 
 # Content
 django-markdownx==1.6

--- a/socialhome/federate/urls.py
+++ b/socialhome/federate/urls.py
@@ -6,7 +6,7 @@ from federation.hostmeta.generators import NODEINFO_DOCUMENT_PATH
 
 from socialhome.federate.views import (
     host_meta_view, webfinger_view, hcard_view, nodeinfo_well_known_view, nodeinfo_view, social_relay_view,
-    ReceivePublicView, ReceiveUserView, content_xml_view)
+    ReceivePublicView, ReceiveUserView, content_xml_view, content_fetch_view)
 
 
 urlpatterns = [
@@ -28,4 +28,5 @@ urlpatterns = [
 
     # Content
     url(r"^p/(?P<guid>[^/]+).xml$", content_xml_view, name="content-xml"),
+    url(r"^fetch/(?P<objtype>[a-z_]+)/(?P<guid>[^/]+)$", content_fetch_view, name="content-fetch"),
 ]

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -105,14 +105,6 @@ class Profile(models.Model):
         self.rsa_private_key = key.exportKey()
 
     @property
-    def key(self):
-        """Required by Social-Federation.
-
-        Corresponds to public key.
-        """
-        return RSA.importKey(self.rsa_private_key)
-
-    @property
     def private_key(self):
         """Required by Social-Federation.
 

--- a/socialhome/users/tests/test_models.py
+++ b/socialhome/users/tests/test_models.py
@@ -75,10 +75,10 @@ class TestProfile(object):
         assert str(profile) == "foo (foo@example.com)"
 
     @pytest.mark.usefixtures("settings")
-    def test_key(self, settings):
+    def test_private_key(self, settings):
         settings.SOCIALHOME_GENERATE_USER_RSA_KEYS_ON_SAVE = True
         user = UserFactory()
-        assert user.profile.key
+        assert user.profile.private_key
 
     def test_get_first_name(self):
         user = UserFactory()


### PR DESCRIPTION
 Diaspora protocol defines this as a view to fetch signed content from remote.

Closes #54
