### PR TITLE
Upgrade to Celery 3.1.25

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -45,7 +45,7 @@ django-redis==4.7.0
 redis>=2.10.0
 
 # Tasks
-celery==3.1.23
+celery==3.1.25
 
 # Generic Django utils
 django-extensions==1.7.5


### PR DESCRIPTION
As suggested the first step in upgrading to Celery 4.0