### PR TITLE
Fix disconnecting websockets by locking Twisted

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,6 +10,10 @@ django==1.10.5
 # Channels
 channels==1.0.2
 asgi_redis==1.0.0
+# Lock Twisted, 17.1.0 broke websockets with constant disconnect/reconnect and console errors like
+# Error: The connection to <websocket> was interrupted while the page was loading.
+# TODO: monitor Twisted and Channels changelogs to free this version lock
+Twisted==16.6.0
 
 # Configuration
 django-environ==0.4.1


### PR DESCRIPTION
Twisted 17.1.0 broke websockets, introducing constant disconnects. Lock to good known version 16.6.0 for now.