### PR TITLE
Raise 404 instead of 500 if no profile found on ProfileDetailView

### DIFF
--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -50,7 +50,7 @@ class ProfileDetailView(AccessMixin, DetailView):
 
         Redirect to login if not allowed to see profile.
         """
-        self.target_profile = Profile.objects.get(guid=self.kwargs.get("guid"))
+        self.target_profile = get_object_or_404(Profile, guid=self.kwargs.get("guid"))
         if self.target_profile.visibility == Visibility.PUBLIC:
             return super(ProfileDetailView, self).dispatch(request, *args, **kwargs)
         if request.user.is_authenticated():


### PR DESCRIPTION
Our custom dispatch caused a 500 if profile user was trying to view didn't exist. Correctly return 404 if no object found.