### PR TITLE
Design tweaks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
             },
             sass: {
                 files: ['<%= paths.sass %>/**/*.{scss,sass}'],
-                tasks: ['sass:dev'],
+                tasks: ['sass:dev', 'concat', 'copy'],
                 options: {
                     atBegin: true
                 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -68,6 +68,7 @@ beautifulsoup4==4.5.3
 lxml==3.7.2
 pyembed==1.3.3
 python-opengraph==0.0.2
+arrow==0.10.0
 
 # IPython for administration
 ipython

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -270,7 +270,9 @@ class Content(models.Model):
             rendered.append({
                 "id": content.id,
                 "author": content.author_id,
-                "rendered": content.rendered
+                "rendered": content.rendered,
+                "humanized_timestamp": content.humanized_timestamp,
+                "formatted_timestamp": content.formatted_timestamp,
             })
         return rendered
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -108,11 +108,15 @@ class TestContentModel(TestCase):
                 "id": self.public_content.id,
                 "author": self.public_content.author_id,
                 "rendered": "<p><strong>Foobar</strong></p>",
+                "humanized_timestamp": self.public_content.humanized_timestamp,
+                "formatted_timestamp": self.public_content.formatted_timestamp,
             },
             {
                 "id": self.site_content.id,
                 "author": self.site_content.author_id,
                 "rendered": "<p><em>Foobar</em></p>",
+                "humanized_timestamp": self.site_content.humanized_timestamp,
+                "formatted_timestamp": self.site_content.formatted_timestamp,
             }
         ])
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -16,6 +16,7 @@ from socialhome.users.tests.factories import ProfileFactory
 
 
 @pytest.mark.usefixtures("db")
+@freeze_time("2017-03-11")
 class TestContentModel(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/socialhome/static/js/grids.js
+++ b/socialhome/static/js/grids.js
@@ -4,6 +4,7 @@
         var $grid = $('.grid').masonry({
             itemSelector: '.grid-item',
             columnWidth: '.grid-sizer',
+            gutter: '.gutter-sizer',
             percentPosition: true,
             stamp: ".stamped",
         });

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -20,7 +20,13 @@ $(function () {
         },
 
         createContentElem: function(content) {
-            return $('<div class="grid-item">' + content + '</div>');
+            return $(
+                '<div class="grid-item">' + content.rendered +
+                    '<div class="grid-item-bar">' +
+                        '<span title="'+ content.formatted_timestamp + '">' + content.humanized_timestamp + '</span>' +
+                    '</div>' +
+                '</div>'
+            );
         },
 
         addContentToGrid: function($contents) {
@@ -124,7 +130,7 @@ $(function () {
                     ids = [];
 
                 _.each(data.contents, function (content) {
-                    var $elem = view.createContentElem(content.rendered);
+                    var $elem = view.createContentElem(content);
                     $contents = $contents ? $contents.add($elem) : $elem;
                     ids.push(content.id);
                 });

--- a/socialhome/static/js/tests/test_streams.js
+++ b/socialhome/static/js/tests/test_streams.js
@@ -73,12 +73,18 @@ describe("Streams", function() {
             });
 
             it("adds new content to grid on content message", function(done) {
-                window.mockServer.send(
-                    '{"event": "content", "contents": [{"id": 1, ' +
-                    '"rendered": "adds new content"}]}'
-                );
+                var message = {
+                    event: "content",
+                    contents: [{
+                        id: 1, rendered: "adds new content", humanized_timestamp: "2 minutes ago",
+                        formatted_timestamp: "2017-01-02 10:11:12+00:00"
+                    }]
+                };
+                window.mockServer.send(JSON.stringify(message));
                 setTimeout(function () {
                     expect($(".grid-item:contains('adds new content')").length).to.eq(1);
+                    expect($(".grid-item-bar > span:contains('2 minutes ago')").length).to.eq(1);
+                    expect($(".grid-item-bar > span[title='2017-01-02 10:11:12+00:00']").length).to.eq(1);
                     done();
                 }, 500);
             });

--- a/socialhome/static/sass/common.scss
+++ b/socialhome/static/sass/common.scss
@@ -39,7 +39,8 @@ html {
 }
 
 body {
-  background-color: black;
+  background-color: $darker;
+  color: $lightish;
 }
 
 // Generic utility classes
@@ -49,5 +50,5 @@ body {
 
 // Main container
 .main-container {
-  margin-top: 40px;
+  margin-top: 60px;
 }

--- a/socialhome/static/sass/grids.scss
+++ b/socialhome/static/sass/grids.scss
@@ -1,7 +1,8 @@
 @import "variables";
 
 .grid-item, .stamped {
-  background-color: #F1F1F1;
+  background-color: $light;
+  color: $dark;
 
   .grid-item-actions {
     font-size: small;
@@ -49,6 +50,7 @@
   .card {
     max-height: 100px;
     overflow: hidden;
+    color: $dark;
 
     .fa-arrows-alt {
       opacity: 0.6;

--- a/socialhome/static/sass/grids.scss
+++ b/socialhome/static/sass/grids.scss
@@ -14,36 +14,57 @@
   }
 }
 
+.stamped {
+  position: relative;
+  top: 10px;
+}
+@media all and (min-width: $mediumDevice) {
+  .stamped {
+    top: 11px;
+  }
+}
+@media all and (min-width: $largeDevice) {
+  .stamped {
+    top: 15px;
+  }
+}
+@media all and (min-width: $extraLargeDevice) {
+  .stamped {
+    top: 16px;
+  }
+}
+
 // Responsive grid sizes
 .grid-sizer,
 .grid-item, .stamped {
   width: 100%;
   padding: 2%;
-  margin: 1% 0;
+  margin-top: 1%;
 }
 @media all and (min-width: $mediumDevice) {
   .grid-sizer,
   .grid-item, .stamped {
-    width: 48%;
+    width: 49.5%;
     padding: 1%;
-    margin: 1%;
   }
 }
 @media all and (min-width: $largeDevice) {
   .grid-sizer,
   .grid-item, .stamped {
-    width: 32.1%;
+    width: 32.6%;
     padding: 1%;
-    margin: 0.5%;
   }
 }
 @media all and (min-width: $extraLargeDevice) {
   .grid-sizer,
   .grid-item, .stamped {
-    width: 24%;
+    width: 24.2%;
     padding: 0.5%;
-    margin: 0.5%;
   }
+}
+
+.gutter-sizer {
+  width: 1%;
 }
 
 .organize-content {

--- a/socialhome/static/sass/grids.scss
+++ b/socialhome/static/sass/grids.scss
@@ -2,7 +2,6 @@
 
 .grid-item, .stamped {
   background-color: #F1F1F1;
-  border-radius: 6px;
 
   .grid-item-actions {
     font-size: small;

--- a/socialhome/static/sass/grids.scss
+++ b/socialhome/static/sass/grids.scss
@@ -4,8 +4,8 @@
   background-color: $light;
   color: $dark;
 
-  .grid-item-actions {
-    font-size: small;
+  .grid-item-bar {
+    font-size: smaller;
     opacity: 0.5;
   }
 

--- a/socialhome/static/sass/streams.scss
+++ b/socialhome/static/sass/streams.scss
@@ -50,3 +50,7 @@
   width: 100%;
   text-align: center;
 }
+
+.streams-container {
+  margin-top: -20px;
+}

--- a/socialhome/static/sass/variables.scss
+++ b/socialhome/static/sass/variables.scss
@@ -9,10 +9,16 @@ $bsMediumDevice: 768px;
 $bsLargeDevice: 992px;
 $bsXLargeDevice: 1200px;
 
-// Alert colors
+// Alert colours
 $white: #fff;
 $mint-green: #d6e9c6;
 $black: #000;
 $pink: #f2dede;
 $dark-pink: #eed3d7;
 $red: #b94a48;
+
+// Common colours
+$dark: #373a3c;
+$darker: #0d1012;
+$light: #F1F1F1;
+$lightish: #d8d8d8;

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -16,11 +16,12 @@
         <div class="row">
             <div class="col-sm-12">
                 <div class="grid">
-                    <div class="grid-sizer"></div>
                     <div class="stamped">
                         {% block stream_description %}{% endblock %}
                     </div>
                     {% block stream_actions %}{% endblock %}
+                    <div class="grid-sizer"></div>
+                    <div class="gutter-sizer"></div>
                     {% for content in content_list %}
                         <div class="grid-item">
                             <div class="grid-item-actions text-sm-right">

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -24,13 +24,15 @@
                     <div class="gutter-sizer"></div>
                     {% for content in content_list %}
                         <div class="grid-item">
-                            <div class="grid-item-actions text-sm-right">
+                            {{ content.rendered|safe }}
+                            <div class="grid-item-bar">
+                                <span title="{{ content.formatted_timestamp }}">{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}</span>
                                 {% if content.author == request.user.profile %}
-                                    <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" aria-label="{% trans "Update" %}"></i></a>
-                                    <a href="{% url "content:delete" content.id %}"><i class="fa fa-remove" aria-label="{% trans "Delete" %}"></i></a>
+                                    &nbsp;
+                                    <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>
+                                    <a href="{% url "content:delete" content.id %}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
                                 {% endif %}
                             </div>
-                            {{ content.rendered|safe }}
                         </div>
                     {% endfor %}
                 </div>

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -5,32 +5,34 @@
 
 {% block content %}
     <script>var socialhomeStream = "{{ stream_name }}";</script>
-    <div class="container">
-        <div id="new-content-container" class="hidden">
-            <a href="" id="new-content-load-link" onclick="return false;">
-                <span class="tag tag-pill tag-primary"><span id="new-content-count">0</span> {% trans "new posts available" %}</span>
-            </a>
+    <div class="streams-container">
+        <div class="container">
+            <div id="new-content-container" class="hidden">
+                <a href="" id="new-content-load-link" onclick="return false;">
+                    <span class="tag tag-pill tag-primary"><span id="new-content-count">0</span> {% trans "new posts available" %}</span>
+                </a>
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-sm-12">
-            <div class="grid">
-                <div class="grid-sizer"></div>
-                <div class="stamped">
-                    {% block stream_description %}{% endblock %}
-                </div>
-                {% block stream_actions %}{% endblock %}
-                {% for content in content_list %}
-                    <div class="grid-item">
-                        <div class="grid-item-actions text-sm-right">
-                            {% if content.author == request.user.profile %}
-                                <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" aria-label="{% trans "Update" %}"></i></a>
-                                <a href="{% url "content:delete" content.id %}"><i class="fa fa-remove" aria-label="{% trans "Delete" %}"></i></a>
-                            {% endif %}
-                        </div>
-                        {{ content.rendered|safe }}
+        <div class="row">
+            <div class="col-sm-12">
+                <div class="grid">
+                    <div class="grid-sizer"></div>
+                    <div class="stamped">
+                        {% block stream_description %}{% endblock %}
                     </div>
-                {% endfor %}
+                    {% block stream_actions %}{% endblock %}
+                    {% for content in content_list %}
+                        <div class="grid-item">
+                            <div class="grid-item-actions text-sm-right">
+                                {% if content.author == request.user.profile %}
+                                    <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" aria-label="{% trans "Update" %}"></i></a>
+                                    <a href="{% url "content:delete" content.id %}"><i class="fa fa-remove" aria-label="{% trans "Delete" %}"></i></a>
+                                {% endif %}
+                            </div>
+                            {{ content.rendered|safe }}
+                        </div>
+                    {% endfor %}
+                </div>
             </div>
         </div>
     </div>

--- a/socialhome/streams/tests/test_consumers.py
+++ b/socialhome/streams/tests/test_consumers.py
@@ -4,12 +4,14 @@ from unittest.mock import patch
 import pytest
 from channels.tests import ChannelTestCase, Client
 from django.test import SimpleTestCase
+from freezegun import freeze_time
 
 from socialhome.content.tests.factories import ContentFactory
 from socialhome.streams.consumers import StreamConsumer
 
 
 @pytest.mark.usefixtures("db")
+@freeze_time("2017-03-11")
 class TestStreamConsumerReceive(ChannelTestCase):
     @classmethod
     def setUpTestData(cls):

--- a/socialhome/streams/tests/test_consumers.py
+++ b/socialhome/streams/tests/test_consumers.py
@@ -36,6 +36,8 @@ class TestStreamConsumerReceive(ChannelTestCase):
                 "id": self.content.id,
                 "author": self.content.author.id,
                 "rendered": self.content.rendered,
+                "humanized_timestamp": self.content.humanized_timestamp,
+                "formatted_timestamp": self.content.formatted_timestamp,
             }
         ])
 


### PR DESCRIPTION
* Lose the rounding on the grid boxes
* Fix some colours and top margin for non-stream pages
* Fix some layouting issues with grids
* Move grid item actions under content. Also add time when content was created.

Refs: #104 

TODO:
* [x] Ensure dynamic loaded content also uses same grid item layout
* [x] Should timestamp shown be edited, not created? For profiles this makes more sense.
* [x] Fix content delete styling