### PR TITLE
Content view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ env.local
 socialhome/static/css/*.css
 socialhome/static/js/project.js
 socialhome/static/fonts/
+!/socialhome/static/fonts/.gitkeep
 staticfiles/
 
 # Bower

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -185,6 +185,10 @@ class Content(models.Model):
     def formatted_timestamp(self):
         return arrow.get(self.modified).format()
 
+    @property
+    def short_text(self):
+        return truncate_letters(self.text, 50)
+
     def render(self):
         """Pre-render text to Content.rendered."""
         text = self.get_and_linkify_tags()

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -294,8 +294,7 @@ class Content(models.Model):
         """
         self.text = re.sub(r"!\[\]\(/media/markdownx/", "![](%s/media/markdownx/" % settings.SOCIALHOME_URL, self.text)
 
-    @property
-    def dict_for_view(self):
+    def dict_for_view(self, request):
         humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
         return {
             "guid": self.guid,
@@ -305,4 +304,5 @@ class Content(models.Model):
             "author_image": self.author.image_url_small,
             "humanized_timestamp": humanized_timestamp,
             "formatted_timestamp": self.formatted_timestamp,
+            "is_author": bool(request.user.is_authenticated and self.author == request.user.profile),
         }

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -12,6 +12,7 @@ from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.utils.text import truncate_letters
 from enumfields import EnumIntegerField
@@ -189,6 +190,10 @@ class Content(models.Model):
     def short_text(self):
         return truncate_letters(self.text, 50)
 
+    @property
+    def slug(self):
+        return slugify(self.short_text)
+
     def render(self):
         """Pre-render text to Content.rendered."""
         text = self.get_and_linkify_tags()
@@ -297,6 +302,7 @@ class Content(models.Model):
     def dict_for_view(self, request):
         humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
         return {
+            "id": self.id,
             "guid": self.guid,
             "rendered": self.rendered,
             "author_name": self.author.name,
@@ -305,4 +311,5 @@ class Content(models.Model):
             "humanized_timestamp": humanized_timestamp,
             "formatted_timestamp": self.formatted_timestamp,
             "is_author": bool(request.user.is_authenticated and self.author == request.user.profile),
+            "slug": self.slug,
         }

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -301,6 +301,7 @@ class Content(models.Model):
 
     def dict_for_view(self, request):
         humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
+        is_author = bool(request.user.is_authenticated and self.author == request.user.profile)
         return {
             "id": self.id,
             "guid": self.guid,
@@ -310,6 +311,8 @@ class Content(models.Model):
             "author_image": self.author.image_url_small,
             "humanized_timestamp": humanized_timestamp,
             "formatted_timestamp": self.formatted_timestamp,
-            "is_author": bool(request.user.is_authenticated and self.author == request.user.profile),
+            "is_author": is_author,
             "slug": self.slug,
+            "update_url": reverse("content:update", kwargs={"pk": self.id}) if is_author else "",
+            "delete_url": reverse("content:delete", kwargs={"pk": self.id}) if is_author else "",
         }

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -273,6 +273,7 @@ class Content(models.Model):
         for content in contents:
             rendered.append({
                 "id": content.id,
+                "guid": content.guid,
                 "author": content.author_id,
                 "rendered": content.rendered,
                 "humanized_timestamp": content.humanized_timestamp,
@@ -295,10 +296,13 @@ class Content(models.Model):
 
     @property
     def dict_for_view(self):
+        humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
         return {
             "guid": self.guid,
             "rendered": self.rendered,
             "author_name": self.author.name,
             "author_handle": self.author.handle,
             "author_image": self.author.image_url_small,
+            "humanized_timestamp": humanized_timestamp,
+            "formatted_timestamp": self.formatted_timestamp,
         }

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -258,7 +258,7 @@ class Content(models.Model):
     @staticmethod
     def get_contents_for_user(ids, user):
         contents = Content.objects.filter(id__in=ids)
-        if not user.is_authenticated():
+        if not user.is_authenticated:
             contents = contents.filter(visibility=Visibility.PUBLIC)
         else:
             contents = contents.filter(

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -292,7 +292,7 @@ class Content(models.Model):
     @property
     def dict_for_view(self):
         return {
-            "id": self.id,
+            "guid": self.guid,
             "rendered": self.rendered,
             "author_name": self.author.name,
             "author_handle": self.author.handle,

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<div class="{% if modal %}modal{% endif %}" id="content-modal">
+<div class="{% if modal %}modal{% else %}content-detail{% endif %}" id="content-modal">
     {% if modal %}<div class="modal-dialog modal-lg" role="document">{% endif %}
         <div class="modal-content">
             <div class="modal-header">

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -17,6 +17,11 @@
             </div>
             <div class="content-bar">
                 <span id="content-timestamp" title="{% if content %}{{ content.formatted_timestamp }}{% endif %}">{% if content %}{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}{% endif %}</span>
+                <span id="content-bar-actions" class="{% if not content or content.author != request.user.profile %}hidden{% endif %}">
+                    &nbsp;
+                    <a href="{% if content %}{% url "content:update" content.id %}{% endif %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>
+                    <a href="{% if content %}{% url "content:delete" content.id %}{% endif %}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
+                </span>
             </div>
             {% if modal %}
                 <div class="modal-footer">

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -19,8 +19,8 @@
                 <span id="content-timestamp" title="{% if content %}{{ content.formatted_timestamp }}{% endif %}">{% if content %}{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}{% endif %}</span>
                 <span id="content-bar-actions" class="{% if not content or content.author != request.user.profile %}hidden{% endif %}">
                     &nbsp;
-                    <a href="{% if content %}{% url "content:update" content.id %}{% endif %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>
-                    <a href="{% if content %}{% url "content:delete" content.id %}{% endif %}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
+                    <a id="content-update-link" href="{% if content %}{% url "content:update" content.id %}{% endif %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>
+                    <a id="content-delete-link" href="{% if content %}{% url "content:delete" content.id %}{% endif %}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
                 </span>
             </div>
             {% if modal %}

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -1,0 +1,28 @@
+{% load i18n %}
+
+<div class="{% if modal %}modal{% endif %}" id="content-modal">
+    {% if modal %}<div class="modal-dialog modal-lg" role="document">{% endif %}
+        <div class="modal-content">
+            <div class="modal-header">
+                <img src="{% if content %}{{ content.author.image_url_small }}{% endif %}" id="content-profile-pic">
+                <h5 id="content-title" class="modal-title">{% if content %}{{ content.author.name }} &lt;{{ content.author.handle }}&gt;{% endif %}</h5>
+                {% if modal %}
+                    <button type="button" class="close" data-dismiss="modal" aria-label="{% trans "Close" %}">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                {% endif %}
+            </div>
+            <div id="content-body" class="modal-body">
+                {% if content %}{{ content.rendered|safe }}{% endif %}
+            </div>
+            <div class="content-bar">
+                <span id="content-timestamp" title="{% if content %}{{ content.formatted_timestamp }}{% endif %}">{% if content %}{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}{% endif %}</span>
+            </div>
+            {% if modal %}
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
+                </div>
+            {% endif %}
+        </div>
+    {% if modal %}</div>{% endif %}
+</div>

--- a/socialhome/content/templates/content/detail.html
+++ b/socialhome/content/templates/content/detail.html
@@ -15,13 +15,5 @@
 
 {% block content %}
     <script>var socialhomeStream = "content-{{ content.guid }}";</script>
-    <div id="content-detail">
-        <div id="content-header">
-            <img src="{{ content.author.image_url_small }}" id="content-profile-pic">
-            <h5 id="content-title">{{ content.author.name }} &lt;{{ content.author.handle }}&gt;</h5>
-            <span class="pull-right" title="{{ content.formatted_timestamp }}">{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}</span>
-        </div>
-        <div id="content-body">{{ content.rendered|safe }}</div>
-        {#<div id="content-footer"></div>#}
-    </div>
+    {% include "content/_content_detail.html" with modal=False content=content %}
 {% endblock %}

--- a/socialhome/content/templates/content/detail.html
+++ b/socialhome/content/templates/content/detail.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {{ content.short_text }}
+{% endblock %}
+
+{% block content %}
+    <script>var socialhomeStream = "content-{{ content.guid }}";</script>
+    <div id="content-detail">
+        <div id="content-header">
+            <img src="{{ content.author.image_url_small }}" id="content-profile-pic">
+            <h5 id="content-title">{{ content.author.name }} &lt;{{ content.author.handle }}&gt;</h5>
+            <span class="pull-right" title="{{ content.formatted_timestamp }}">{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}</span>
+        </div>
+        <div id="content-body">{{ content.rendered|safe }}</div>
+        {#<div id="content-footer"></div>#}
+    </div>
+{% endblock %}

--- a/socialhome/content/templates/content/detail.html
+++ b/socialhome/content/templates/content/detail.html
@@ -5,6 +5,14 @@
     {{ content.short_text }}
 {% endblock %}
 
+{% block ogtags %}
+    <meta property="og:title" content="{{ content.short_text }}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://{{ request.site.domain }}{{ request.path }}" />
+    {# TODO find an image from content #}
+    <meta property="og:image" content="https://socialhome.network/media/markdownx/74b37fa1-88d0-4e29-9fdc-8d07ba216f63.png" />
+{% endblock %}
+
 {% block content %}
     <script>var socialhomeStream = "content-{{ content.guid }}";</script>
     <div id="content-detail">

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -185,7 +185,7 @@ class TestContentModel(TestCase):
 
     def test_dict_for_view(self):
         self.assertEqual(self.public_content.dict_for_view, {
-            "id": self.public_content.id,
+            "guid": self.public_content.guid,
             "rendered": self.public_content.rendered,
             "author_name": self.public_content.author.name,
             "author_handle": self.public_content.author.handle,

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -220,7 +220,7 @@ class TestContentSaveTags(TestCase):
     def test_factory_instance_has_tags(self):
         self.assertTrue(Tag.objects.filter(name="tag").exists())
         self.assertTrue(Tag.objects.filter(name="othertag").exists())
-        self.assertEquals(self.content.tags.count(), 2)
+        self.assertEqual(self.content.tags.count(), 2)
         tags = set(self.content.tags.values_list("name", flat=True))
         self.assertEqual(tags, {"tag", "othertag"})
 
@@ -230,14 +230,14 @@ class TestContentSaveTags(TestCase):
         self.assertTrue(Tag.objects.filter(name="third").exists())
         self.assertTrue(Tag.objects.filter(name="post").exists())
         self.assertTrue(Tag.objects.filter(name="fourth").exists())
-        self.assertEquals(self.content.tags.count(), 5)
+        self.assertEqual(self.content.tags.count(), 5)
         tags = set(self.content.tags.values_list("name", flat=True))
         self.assertEqual(tags, {"tag", "othertag", "third", "post", "fourth"})
 
     def test_extract_tags_removes_old_tags(self):
         self.content.text = "**Foobar** #tag #third"
         self.content.save()
-        self.assertEquals(self.content.tags.count(), 2)
+        self.assertEqual(self.content.tags.count(), 2)
         tags = set(self.content.tags.values_list("name", flat=True))
         self.assertEqual(tags, {"tag", "third"})
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db import IntegrityError, transaction
 from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.timezone import make_aware
 from freezegun import freeze_time
 from test_plus import TestCase
@@ -187,6 +188,7 @@ class TestContentModel(TestCase):
 
     def test_dict_for_view(self):
         self.assertEqual(self.public_content.dict_for_view(Mock()), {
+            "id": self.public_content.id,
             "guid": self.public_content.guid,
             "rendered": self.public_content.rendered,
             "author_name": self.public_content.author.name,
@@ -195,6 +197,9 @@ class TestContentModel(TestCase):
             "humanized_timestamp": self.public_content.humanized_timestamp,
             "formatted_timestamp": self.public_content.formatted_timestamp,
             "is_author": False,
+            "slug": self.public_content.slug,
+            "update_url": "",
+            "delete_url": "",
         })
 
     def test_dict_for_view_for_author(self):
@@ -205,6 +210,7 @@ class TestContentModel(TestCase):
             )
         )
         self.assertEqual(self.public_content.dict_for_view(request), {
+            "id": self.public_content.id,
             "guid": self.public_content.guid,
             "rendered": self.public_content.rendered,
             "author_name": self.public_content.author.name,
@@ -213,6 +219,9 @@ class TestContentModel(TestCase):
             "humanized_timestamp": self.public_content.humanized_timestamp,
             "formatted_timestamp": self.public_content.formatted_timestamp,
             "is_author": True,
+            "slug": self.public_content.slug,
+            "update_url": reverse("content:update", kwargs={"pk": self.public_content.id}),
+            "delete_url": reverse("content:delete", kwargs={"pk": self.public_content.id}),
         })
 
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -107,6 +107,7 @@ class TestContentModel(TestCase):
         self.assertEqual(contents, [
             {
                 "id": self.public_content.id,
+                "guid": self.public_content.guid,
                 "author": self.public_content.author_id,
                 "rendered": "<p><strong>Foobar</strong></p>",
                 "humanized_timestamp": self.public_content.humanized_timestamp,
@@ -114,6 +115,7 @@ class TestContentModel(TestCase):
             },
             {
                 "id": self.site_content.id,
+                "guid": self.site_content.guid,
                 "author": self.site_content.author_id,
                 "rendered": "<p><em>Foobar</em></p>",
                 "humanized_timestamp": self.site_content.humanized_timestamp,
@@ -190,6 +192,8 @@ class TestContentModel(TestCase):
             "author_name": self.public_content.author.name,
             "author_handle": self.public_content.author.handle,
             "author_image": self.public_content.author.image_url_small,
+            "humanized_timestamp": self.public_content.humanized_timestamp,
+            "formatted_timestamp": self.public_content.formatted_timestamp,
         })
 
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -186,7 +186,7 @@ class TestContentModel(TestCase):
             self.assertTrue(self.public_content.edited)
 
     def test_dict_for_view(self):
-        self.assertEqual(self.public_content.dict_for_view, {
+        self.assertEqual(self.public_content.dict_for_view(Mock()), {
             "guid": self.public_content.guid,
             "rendered": self.public_content.rendered,
             "author_name": self.public_content.author.name,
@@ -194,6 +194,25 @@ class TestContentModel(TestCase):
             "author_image": self.public_content.author.image_url_small,
             "humanized_timestamp": self.public_content.humanized_timestamp,
             "formatted_timestamp": self.public_content.formatted_timestamp,
+            "is_author": False,
+        })
+
+    def test_dict_for_view_for_author(self):
+        request = Mock(
+            user=Mock(
+                is_authenticated=True,
+                profile=self.public_content.author,
+            )
+        )
+        self.assertEqual(self.public_content.dict_for_view(request), {
+            "guid": self.public_content.guid,
+            "rendered": self.public_content.rendered,
+            "author_name": self.public_content.author.name,
+            "author_handle": self.public_content.author.handle,
+            "author_image": self.public_content.author.image_url_small,
+            "humanized_timestamp": self.public_content.humanized_timestamp,
+            "formatted_timestamp": self.public_content.formatted_timestamp,
+            "is_author": True,
         })
 
 

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from django.core.urlresolvers import reverse
@@ -10,7 +10,8 @@ from socialhome.enums import Visibility
 from socialhome.content.forms import ContentForm
 from socialhome.content.models import Content
 from socialhome.content.tests.factories import ContentFactory, LocalContentFactory
-from socialhome.content.views import ContentCreateView, ContentUpdateView, ContentDeleteView
+from socialhome.content.views import ContentCreateView, ContentUpdateView, ContentDeleteView, \
+    PublicOrOwnedByUserContentMixin
 from socialhome.users.models import Profile
 from socialhome.users.tests.factories import UserFactory
 
@@ -195,8 +196,7 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(self.content.dict_for_view(Mock()), data)
+        self.assertEqual(self.content.dict_for_view(Mock()), response.json())
 
     def test_content_view_by_guid_renders_json_result(self):
         response = self.client.get(
@@ -204,8 +204,15 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
-        data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(self.content.dict_for_view(Mock()), data)
+        self.assertEqual(self.content.dict_for_view(Mock()), response.json())
+
+    def test_content_view_by_slug_renders_json_result(self):
+        response = self.client.get(
+            reverse("content:view-by-slug", kwargs={"pk": self.content.id, "slug": self.content.slug}),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.content.dict_for_view(Mock()), response.json())
 
     def test_content_view_returns_404_for_private_content_except_if_owned(self):
         self.client.force_login(self.content.author.user)
@@ -220,3 +227,108 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_content_view_renders(self):
+        response = self.client.get(
+            reverse("content:view", kwargs={"pk": self.content.id})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_view_renders_by_guid(self):
+        response = self.client.get(
+            reverse("content:view-by-guid", kwargs={"guid": self.content.guid}),
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_view_renders_by_slug(self):
+        response = self.client.get(
+            reverse("content:view-by-slug", kwargs={"pk": self.content.id, "slug": self.content.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_content_view_content(self):
+        response = self.client.get(
+            reverse("content:view", kwargs={"pk": self.content.id})
+        )
+        self.assertNotContains(response, "modal-dialog modal-lg")
+        self.assertContains(response, self.content.author.image_url_small)
+        self.assertContains(response, self.content.author.name)
+        self.assertContains(response, self.content.author.handle)
+        self.assertNotContains(response, 'data-dismiss="modal"')
+        self.assertContains(response, self.content.rendered)
+        self.assertContains(response, self.content.humanized_timestamp)
+        self.assertContains(response, self.content.formatted_timestamp)
+        self.assertContains(response, '<span id="content-bar-actions" class="hidden"')
+        self.assertNotContains(response, "modal-footer")
+        self.assertContains(response, 'var socialhomeStream = "content-%s' % self.content.guid)
+
+    def test_content_view_content_as_author(self):
+        self.client.force_login(self.content.author.user)
+        response = self.client.get(
+            reverse("content:view", kwargs={"pk": self.content.id})
+        )
+        self.assertNotContains(response, '<span id="content-bar-actions" class="hidden"')
+
+
+class MockPublicOrOwnedProtectedView(PublicOrOwnedByUserContentMixin):
+    mock_object = None
+    author = "profile"
+
+    def __init__(self, visibility):
+        self.mock_object = Mock(
+            visibility=visibility,
+            author=self.author
+        )
+
+    def get_object(self):
+        return self.mock_object
+
+
+class PublicOrOwnedByUserContentMixin(TestCase):
+    def test_public_content_is_true(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.PUBLIC)
+        self.assertTrue(view.test_func(Mock(profile=Mock())))
+
+    def test_limited_content_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.LIMITED)
+        self.assertFalse(view.test_func(Mock(profile=Mock())))
+
+    def test_site_content_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SITE)
+        self.assertFalse(view.test_func(Mock(profile=Mock())))
+
+    def test_self_content_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SELF)
+        self.assertFalse(view.test_func(Mock(profile=Mock())))
+
+    def test_public_content_no_profile_is_true(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.PUBLIC)
+        self.assertTrue(view.test_func(Mock()))
+
+    def test_limited_content_no_profile_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.LIMITED)
+        self.assertFalse(view.test_func(Mock()))
+
+    def test_site_content_no_profile_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SITE)
+        self.assertFalse(view.test_func(Mock()))
+
+    def test_self_content_no_profile_is_false(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SELF)
+        self.assertFalse(view.test_func(Mock()))
+
+    def test_public_content_is_true_if_owned(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.PUBLIC)
+        self.assertTrue(view.test_func(Mock(profile=view.author)))
+
+    def test_limited_content_is_true_if_owned(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.LIMITED)
+        self.assertTrue(view.test_func(Mock(profile=view.author)))
+
+    def test_site_content_is_true_if_owned(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SITE)
+        self.assertTrue(view.test_func(Mock(profile=view.author)))
+
+    def test_self_content_is_true_if_owned(self):
+        view = MockPublicOrOwnedProtectedView(Visibility.SELF)
+        self.assertTrue(view.test_func(Mock(profile=view.author)))

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock
 
 import pytest
 from django.core.urlresolvers import reverse
@@ -195,7 +196,7 @@ class TestContentView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(self.content.dict_for_view, data)
+        self.assertEqual(self.content.dict_for_view(Mock()), data)
 
     def test_content_view_by_guid_renders_json_result(self):
         response = self.client.get(
@@ -204,7 +205,7 @@ class TestContentView(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content.decode("utf-8"))
-        self.assertEqual(self.content.dict_for_view, data)
+        self.assertEqual(self.content.dict_for_view(Mock()), data)
 
     def test_content_view_returns_404_for_private_content_except_if_owned(self):
         self.client.force_login(self.content.author.user)

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -187,9 +187,18 @@ class TestContentView(TestCase):
         cls.content = ContentFactory()
         cls.client = Client()
 
-    def test_content_view_render_json_result(self):
+    def test_content_view_renders_json_result(self):
         response = self.client.get(
             reverse("content:view", kwargs={"pk": self.content.id}),
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(self.content.dict_for_view, data)
+
+    def test_content_view_by_guid_renders_json_result(self):
+        response = self.client.get(
+            reverse("content:view-by-guid", kwargs={"guid": self.content.guid}),
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)

--- a/socialhome/content/urls.py
+++ b/socialhome/content/urls.py
@@ -3,8 +3,14 @@ from django.conf.urls import url
 from socialhome.content.views import ContentCreateView, ContentUpdateView, ContentDeleteView, ContentView
 
 urlpatterns = [
-    url(r"^(?P<pk>[0-9]+)$", ContentView.as_view(), name="view"),
-    url(r"^(?P<guid>[^/]+)$", ContentView.as_view(), name="view-by-guid"),
+    # Content detail works with three different versions
+    # /content/123/  # pk
+    # /content/123/slug/  # pk + slug
+    # /content/abcd-edfg-ffff-aaaa/  # guid
+    url(r"^(?P<pk>[0-9]+)/$", ContentView.as_view(), name="view"),
+    url(r"^(?P<pk>[0-9]+)/(?P<slug>[-\w]+)/$", ContentView.as_view(), name="view-by-slug"),
+    url(r"^(?P<guid>[^/]+)/$", ContentView.as_view(), name="view-by-guid"),
+
     url(r"^create/$", ContentCreateView.as_view(), name="create"),
     url(r"^edit/(?P<pk>[0-9]+)$", ContentUpdateView.as_view(), name="update"),
     url(r"^delete/(?P<pk>[0-9]+)$", ContentDeleteView.as_view(), name="delete"),

--- a/socialhome/content/urls.py
+++ b/socialhome/content/urls.py
@@ -3,6 +3,10 @@ from django.conf.urls import url
 from socialhome.content.views import ContentCreateView, ContentUpdateView, ContentDeleteView, ContentView
 
 urlpatterns = [
+    url(r"^create/$", ContentCreateView.as_view(), name="create"),
+    url(r"^(?P<pk>[0-9]+)/~edit/$", ContentUpdateView.as_view(), name="update"),
+    url(r"^(?P<pk>[0-9]+)/~delete/$", ContentDeleteView.as_view(), name="delete"),
+
     # Content detail works with three different versions
     # /content/123/  # pk
     # /content/123/slug/  # pk + slug
@@ -10,8 +14,4 @@ urlpatterns = [
     url(r"^(?P<pk>[0-9]+)/$", ContentView.as_view(), name="view"),
     url(r"^(?P<pk>[0-9]+)/(?P<slug>[-\w]+)/$", ContentView.as_view(), name="view-by-slug"),
     url(r"^(?P<guid>[^/]+)/$", ContentView.as_view(), name="view-by-guid"),
-
-    url(r"^create/$", ContentCreateView.as_view(), name="create"),
-    url(r"^edit/(?P<pk>[0-9]+)$", ContentUpdateView.as_view(), name="update"),
-    url(r"^delete/(?P<pk>[0-9]+)$", ContentDeleteView.as_view(), name="delete"),
 ]

--- a/socialhome/content/urls.py
+++ b/socialhome/content/urls.py
@@ -4,6 +4,7 @@ from socialhome.content.views import ContentCreateView, ContentUpdateView, Conte
 
 urlpatterns = [
     url(r"^(?P<pk>[0-9]+)$", ContentView.as_view(), name="view"),
+    url(r"^(?P<guid>[^/]+)$", ContentView.as_view(), name="view-by-guid"),
     url(r"^create/$", ContentCreateView.as_view(), name="create"),
     url(r"^edit/(?P<pk>[0-9]+)$", ContentUpdateView.as_view(), name="update"),
     url(r"^delete/(?P<pk>[0-9]+)$", ContentDeleteView.as_view(), name="delete"),

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -53,7 +53,7 @@ class PublicOrOwnedByUserContentMixin(UserPassesTestMixin):
         return (
             bool(object) and (
                 object.visibility == Visibility.PUBLIC or
-                (hasattr(user, "profile")  and object.author == user.profile)
+                (hasattr(user, "profile") and object.author == user.profile)
             )
         )
 

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -85,6 +85,7 @@ class ContentDeleteView(UserOwnsContentMixin, DeleteView):
 
 class ContentView(PublicOrOwnedByUserContentMixin, AjaxResponseMixin, JSONResponseMixin, DetailView):
     model = Content
+    template_name = "content/detail.html"
 
     def get_object(self, queryset=None):
         guid = self.kwargs.get("guid")

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -95,7 +95,7 @@ class ContentView(PublicOrOwnedByUserContentMixin, AjaxResponseMixin, JSONRespon
 
     def get_ajax(self, request, *args, **kwargs):
         self.object = self.get_object()
-        return self.render_json_response(self.object.dict_for_view)
+        return self.render_json_response(self.object.dict_for_view(request))
 
 
 class HomeView(TemplateView):

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -49,11 +49,11 @@ class PublicOrOwnedByUserContentMixin(UserPassesTestMixin):
 
     def test_func(self, user):
         """Ensure content is public or user owns it."""
-        object = self.get_object()
+        obj = self.get_object()
         return (
-            bool(object) and (
-                object.visibility == Visibility.PUBLIC or
-                (hasattr(user, "profile") and object.author == user.profile)
+            bool(obj) and (
+                obj.visibility == Visibility.PUBLIC or
+                (hasattr(user, "profile") and obj.author == user.profile)
             )
         )
 

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -106,6 +106,6 @@ class HomeView(TemplateView):
         if request.user.is_authenticated:
             return ProfileDetailView.as_view()(request, guid=request.user.profile.guid)
         if settings.SOCIALHOME_ROOT_PROFILE:
-            profile = Profile.objects.get(user__username=settings.SOCIALHOME_ROOT_PROFILE)
+            profile = get_object_or_404(Profile, user__username=settings.SOCIALHOME_ROOT_PROFILE)
             return ProfileDetailView.as_view()(request, guid=profile.guid)
         return super(HomeView, self).get(request, *args, **kwargs)

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.http.response import Http404
+from django.shortcuts import get_object_or_404
 from django.views.generic import CreateView, UpdateView, TemplateView, DeleteView, DetailView
 
 from socialhome.content.forms import ContentForm
@@ -67,6 +68,12 @@ class ContentDeleteView(UserOwnsContentMixin, DeleteView):
 
 class ContentView(AjaxResponseMixin, JSONResponseMixin, DetailView):
     model = Content
+
+    def get_object(self, queryset=None):
+        guid = self.kwargs.get("guid")
+        if guid:
+            return get_object_or_404(Content, guid=guid)
+        return super().get_object(queryset=queryset)
 
     def get_ajax(self, request, *args, **kwargs):
         self.object = self.get_object()

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -111,24 +111,32 @@ $(function () {
             $("#content-update-link, #content-delete-link").attr("href", "");
         },
 
+        setContentModalData: function(data) {
+            // Add content to the modal
+            $("#content-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
+            $("#content-body").html(data.rendered);
+            $("#content-profile-pic").attr("src", data.author_image);
+            $("#content-timestamp").attr("title", data.formatted_timestamp).html(data.humanized_timestamp);
+            if (data.is_author) {
+                $("#content-bar-actions").removeClass("hidden");
+                $("#content-update-link").attr("href", data.update_url);
+                $("#content-delete-link").attr("href", data.delete_url);
+            }
+        },
+
         loadContentModal: function(contentGuid) {
-            var content = $.getJSON(
+            $.getJSON(
                 "/content/" + contentGuid + "/",
                 function(data) {
                     // Change URL to the content URL
-                    window.history.pushState(
-                        {content: data.guid}, data.guid, "/content/" + data.id + "/" + data.slug + "/"
-                    );
-                    // Add content to the modal
-                    $("#content-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
-                    $("#content-body").html(data.rendered);
-                    $("#content-profile-pic").attr("src", data.author_image);
-                    $("#content-timestamp").attr("title", data.formatted_timestamp).html(data.humanized_timestamp);
-                    if (data.is_author) {
-                        $("#content-bar-actions").removeClass("hidden");
-                        $("#content-update-link").attr("href", data.update_url);
-                        $("#content-delete-link").attr("href", data.delete_url);
+                    var url = "/content/" + data.id + "/";
+                    if (data.slug !== "/") {
+                        url = url + data.slug + "/"
                     }
+                    window.history.pushState(
+                        {content: data.guid}, data.guid, url
+                    );
+                    view.setContentModalData(data);
                     view.addNSFWShield();
                 }
             );

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -87,7 +87,11 @@ $(function () {
         },
 
         showContentModal: function() {
-            $('#content-modal').modal('show');
+            $('#content-modal').modal('show').on('hide.bs.modal', function (e) {
+                // Push navigation back one level when hiding the modal
+                history.back();
+                $('#content-modal').off("hide.bs.modal");
+            });
             // Close modal on esc key
             $(document).keypress(function (e) {
                 if (e.keyCode == 27) {
@@ -105,6 +109,9 @@ $(function () {
             var content = $.getJSON(
                 "/content/" + contentGuid,
                 function(data) {
+                    // Change URL to the content URL
+                    window.history.pushState({content: data.guid}, data.guid, "/content/" + data.guid);
+                    // Add content to the modal
                     $("#content-modal-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
                     $("#content-modal-body").html(data.rendered);
                     $("#content-modal-profile-pic").attr("src", data.author_image);

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -107,6 +107,7 @@ $(function () {
             $('#content-title, #content-body').html("");
             $("#content-profile-pic").attr("src", "");
             $("#content-timestamp").attr("title", "").html("");
+            $("#content-bar-actions").addClass("hidden");
         },
 
         loadContentModal: function(contentGuid) {
@@ -120,6 +121,9 @@ $(function () {
                     $("#content-body").html(data.rendered);
                     $("#content-profile-pic").attr("src", data.author_image);
                     $("#content-timestamp").attr("title", data.formatted_timestamp).html(data.humanized_timestamp);
+                    if (data.is_author) {
+                        $("#content-bar-actions").removeClass("hidden");
+                    }
                     view.addNSFWShield();
                 }
             );

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -130,7 +130,7 @@ $(function () {
                 function(data) {
                     // Change URL to the content URL
                     var url = "/content/" + data.id + "/";
-                    if (data.slug !== "/") {
+                    if (data.slug !== "") {
                         url = url + data.slug + "/"
                     }
                     window.history.pushState(

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -106,6 +106,7 @@ $(function () {
         cleanContentModal: function() {
             $('#content-title, #content-body').html("");
             $("#content-profile-pic").attr("src", "");
+            $("#content-timestamp").attr("title", "").html("");
         },
 
         loadContentModal: function(contentGuid) {
@@ -118,6 +119,7 @@ $(function () {
                     $("#content-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
                     $("#content-body").html(data.rendered);
                     $("#content-profile-pic").attr("src", data.author_image);
+                    $("#content-timestamp").attr("title", data.formatted_timestamp).html(data.humanized_timestamp);
                     view.addNSFWShield();
                 }
             );

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -88,9 +88,8 @@ $(function () {
 
         showContentModal: function() {
             $('#content-modal').modal('show').on('hide.bs.modal', function (e) {
-                // Push navigation back one level when hiding the modal
-                history.back();
                 $('#content-modal').off("hide.bs.modal");
+                history.back();
             });
             // Close modal on esc key
             $(document).keypress(function (ev) {
@@ -105,8 +104,8 @@ $(function () {
         },
 
         cleanContentModal: function() {
-            $('#content-modal-title, #content-modal-body').html("");
-            $("#content-modal-profile-pic").attr("src", "");
+            $('#content-title, #content-body').html("");
+            $("#content-profile-pic").attr("src", "");
         },
 
         loadContentModal: function(contentGuid) {
@@ -116,9 +115,9 @@ $(function () {
                     // Change URL to the content URL
                     window.history.pushState({content: data.guid}, data.guid, "/content/" + data.guid);
                     // Add content to the modal
-                    $("#content-modal-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
-                    $("#content-modal-body").html(data.rendered);
-                    $("#content-modal-profile-pic").attr("src", data.author_image);
+                    $("#content-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
+                    $("#content-body").html(data.rendered);
+                    $("#content-profile-pic").attr("src", data.author_image);
                     view.addNSFWShield();
                 }
             );
@@ -137,6 +136,7 @@ $(function () {
             this.socket.onclose = this.handleSocketClose;
             // Hide content modal on back navigation
             window.onpopstate = function(ev) {
+                $('#content-modal').off("hide.bs.modal");
                 view.hideContentModal();
             };
         },

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -93,11 +93,15 @@ $(function () {
                 $('#content-modal').off("hide.bs.modal");
             });
             // Close modal on esc key
-            $(document).keypress(function (e) {
-                if (e.keyCode == 27) {
-                    $('#content-modal').modal('hide');
+            $(document).keypress(function (ev) {
+                if (ev.keyCode == 27) {
+                    view.hideContentModal();
                 }
             });
+        },
+
+        hideContentModal: function() {
+            $('#content-modal').modal('hide');
         },
 
         cleanContentModal: function() {
@@ -131,6 +135,10 @@ $(function () {
             this.socket.onmessage = this.handleMessage;
             this.socket.onopen = this.handleSocketOpen;
             this.socket.onclose = this.handleSocketClose;
+            // Hide content modal on back navigation
+            window.onpopstate = function(ev) {
+                view.hideContentModal();
+            };
         },
 
         createConnection: function() {

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -108,6 +108,7 @@ $(function () {
             $("#content-profile-pic").attr("src", "");
             $("#content-timestamp").attr("title", "").html("");
             $("#content-bar-actions").addClass("hidden");
+            $("#content-update-link, #content-delete-link").attr("href", "");
         },
 
         loadContentModal: function(contentGuid) {
@@ -125,6 +126,8 @@ $(function () {
                     $("#content-timestamp").attr("title", data.formatted_timestamp).html(data.humanized_timestamp);
                     if (data.is_author) {
                         $("#content-bar-actions").removeClass("hidden");
+                        $("#content-update-link").attr("href", data.update_url);
+                        $("#content-delete-link").attr("href", data.delete_url);
                     }
                     view.addNSFWShield();
                 }

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -112,10 +112,12 @@ $(function () {
 
         loadContentModal: function(contentGuid) {
             var content = $.getJSON(
-                "/content/" + contentGuid,
+                "/content/" + contentGuid + "/",
                 function(data) {
                     // Change URL to the content URL
-                    window.history.pushState({content: data.guid}, data.guid, "/content/" + data.guid);
+                    window.history.pushState(
+                        {content: data.guid}, data.guid, "/content/" + data.id + "/" + data.slug + "/"
+                    );
                     // Add content to the modal
                     $("#content-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
                     $("#content-body").html(data.rendered);

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -23,7 +23,7 @@ $(function () {
             return $(
                 '<div class="grid-item">' + content.rendered +
                     '<div class="grid-item-bar">' +
-                        '<span class="grid-item-open-action" data-content-id="' + content.id + '" title="'+ content.formatted_timestamp + '">' + content.humanized_timestamp + '</span>' +
+                        '<span class="grid-item-open-action" data-content-guid="' + content.guid + '" title="'+ content.formatted_timestamp + '">' + content.humanized_timestamp + '</span>' +
                     '</div>' +
                 '</div>'
             );
@@ -101,9 +101,9 @@ $(function () {
             $("#content-modal-profile-pic").attr("src", "");
         },
 
-        loadContentModal: function(contentId) {
+        loadContentModal: function(contentGuid) {
             var content = $.getJSON(
-                "/content/" + contentId,
+                "/content/" + contentGuid,
                 function(data) {
                     $("#content-modal-title").html(data.author_name + " &lt;" + data.author_handle + "&gt;");
                     $("#content-modal-body").html(data.rendered);
@@ -183,10 +183,10 @@ $(function () {
         },
 
         loadContentModal: function(ev) {
-            var contentId = $(ev.currentTarget).data("content-id");
+            var contentGuid = $(ev.currentTarget).data("content-guid");
             view.cleanContentModal();
             view.showContentModal();
-            view.loadContentModal(contentId);
+            view.loadContentModal(contentGuid);
         },
 
         addContentListeners: function() {

--- a/socialhome/static/js/tests/test_streams.js
+++ b/socialhome/static/js/tests/test_streams.js
@@ -125,35 +125,100 @@ describe("Streams", function() {
         before(function() {
             server = sinon.fakeServer.create();
             var data = {
-                guid: "1234", rendered: "foobar", author_name: "sinon", author_handle: "mocha@stream_test",
-                author_image: "https://localhost/sinon.jpg",
+                id: 1, guid: "1234", rendered: "foobar barfoo", author_name: "sinon", author_handle: "mocha@stream_test",
+                author_image: "https://localhost/sinon.jpg", slug: "foobar-barfoo",
+                formatted_timestamp: "2017-03-14 22:04:00+00:00", humanized_timestamp: "2 hours ago",
+                is_author: false, update_url: "", delete_url: "",
             };
             server.respondWith(
                 "GET",
-                "/content/1234",
+                "/content/1234/",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(data)]
             );
         });
 
-        context("click on timestamp", function() {
-            it("opens up modal", function() {
+        it("click on timestamp opens up modal", function() {
+            var $modal = $(".modal-content");
+            expect($modal.is(":visible")).to.be.false;
+            $(".grid-item-open-action[data-content-guid=1234]").trigger("click", function(done) {
+                done();
+            });
+            server.respond();
+            expect($modal.is(":visible")).to.be.true;
+            expect($("#content-title:contains('sinon')").length).to.eq(1);
+            expect($("#content-title:contains('mocha@stream_test')").length).to.eq(1);
+            expect($("#content-body:contains('foobar barfoo')").length).to.eq(1);
+            expect($("#content-profile-pic[src='https://localhost/sinon.jpg']").length).to.eq(1);
+            expect($("#content-timestamp[title='2017-03-14 22:04:00+00:00']").length).to.eq(1);
+            expect($("#content-timestamp:contains('2 hours ago')").length).to.eq(1);
+            expect($("#content-bar-actions").hasClass("hidden")).to.be.true;
+            expect($("#content-update-link").attr("href")).to.eq("");
+            expect($("#content-delete-link").attr("href")).to.eq("");
+        });
+
+        context("as author", function() {
+            before(function() {
+                server = sinon.fakeServer.create();
+                var data = {
+                    id: 1, guid: "1234", rendered: "foobar barfoo", author_name: "sinon", author_handle: "mocha@stream_test",
+                    author_image: "https://localhost/sinon.jpg", slug: "foobar-barfoo",
+                    formatted_timestamp: "2017-03-14 22:04:00+00:00", humanized_timestamp: "2 hours ago",
+                    is_author: true, update_url: "http://127.0.0.1:" + runserverPort + "/content/1/~update/",
+                    delete_url: "http://127.0.0.1:" + runserverPort + "/content/1/~delete/",
+                };
+                server.respondWith(
+                    "GET",
+                    "/content/1234/",
+                    [200, { "Content-Type": "application/json" }, JSON.stringify(data)]
+                );
+            });
+
+            it("click on timestamp opens up modal", function() {
                 var $modal = $(".modal-content");
                 expect($modal.is(":visible")).to.be.false;
                 $(".grid-item-open-action[data-content-guid=1234]").trigger("click", function(done) {
                     done();
                 });
                 server.respond();
-                expect($modal.is(":visible")).to.be.true;
-                expect($("#content-modal-title:contains('sinon')").length).to.eq(1);
-                expect($("#content-modal-title:contains('mocha@stream_test')").length).to.eq(1);
-                expect($("#content-modal-body:contains('foobar')").length).to.eq(1);
-                expect($("#content-modal-profile-pic[src='https://localhost/sinon.jpg']").length).to.eq(1);
+                expect($("#content-bar-actions").hasClass("hidden")).to.be.false;
+                expect($("#content-update-link").attr("href")).to.eq("http://127.0.0.1:" + runserverPort + "/content/1/~update/");
+                expect($("#content-delete-link").attr("href")).to.eq("http://127.0.0.1:" + runserverPort + "/content/1/~delete/");
             });
+
+            after(function() {
+                server.restore();
+            });
+        });
+
+        it("changes url to content and then back on hiding modal", function() {
+            var currentUrl = window.location.href;
+            expect(currentUrl).to.not.eq("http://127.0.0.1:" + runserverPort + "/content/1/foobar-barfoo/");
+            $(".grid-item-open-action[data-content-guid=1234]").trigger("click", function(done) {
+                done();
+            });
+            server.respond();
+            expect(window.location.href).to.eq("http://127.0.0.1:" + runserverPort + "/content/1/foobar-barfoo/");
+            $("#content-modal").modal("hide");
+            expect(window.location.href).to.eq(currentUrl);
+        });
+
+        it("hides modal on back navigation", function() {
+            var $modal = $(".modal-content");
+            $(".grid-item-open-action[data-content-guid=1234]").trigger("click", function(done) {
+                done();
+            });
+            server.respond();
+            expect($modal.is(":visible")).to.be.true;
+            history.back();
+            expect($modal.is(":visible")).to.be.false;
+        });
+
+        afterEach(function() {
+            $("#content-modal").modal("hide");
         });
 
         after(function() {
             server.restore();
-            $("#content-modal").modal("hide");
         });
     });
 });

--- a/socialhome/static/js/tests/test_streams.js
+++ b/socialhome/static/js/tests/test_streams.js
@@ -125,12 +125,12 @@ describe("Streams", function() {
         before(function() {
             server = sinon.fakeServer.create();
             var data = {
-                id: 1, rendered: "foobar", author_name: "sinon", author_handle: "mocha@stream_test",
+                guid: "1234", rendered: "foobar", author_name: "sinon", author_handle: "mocha@stream_test",
                 author_image: "https://localhost/sinon.jpg",
             };
             server.respondWith(
                 "GET",
-                "/content/1",
+                "/content/1234",
                 [200, { "Content-Type": "application/json" }, JSON.stringify(data)]
             );
         });
@@ -139,7 +139,7 @@ describe("Streams", function() {
             it("opens up modal", function() {
                 var $modal = $(".modal-content");
                 expect($modal.is(":visible")).to.be.false;
-                $(".grid-item-open-action[data-content-id=1]").trigger("click", function(done) {
+                $(".grid-item-open-action[data-content-guid=1234]").trigger("click", function(done) {
                     done();
                 });
                 server.respond();

--- a/socialhome/static/sass/common.scss
+++ b/socialhome/static/sass/common.scss
@@ -53,13 +53,10 @@ body {
   margin-top: 60px;
 }
 
-// Modals have a light background
+// Modals
 .modal {
   color: $dark;
-
-  .modal-content {
-    border-radius: unset;
-  }
+  border-radius: unset;
 }
 
 // Lose the rounding on buttons

--- a/socialhome/static/sass/common.scss
+++ b/socialhome/static/sass/common.scss
@@ -52,10 +52,25 @@ body {
 .main-container {
   margin-top: 60px;
 }
+@media all and (max-width: $mediumDevice) {
+  .main-container {
+    width: 100%;
+    max-width: unset;
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
 
 // Modals
 .modal {
   color: $dark;
+}
+@media all and (max-width: $mediumDevice) {
+  .modal-lg {
+    width: 100%;
+    max-width: unset;
+    margin: 0;
+  }
 }
 
 // Lose the rounding on buttons

--- a/socialhome/static/sass/common.scss
+++ b/socialhome/static/sass/common.scss
@@ -56,7 +56,6 @@ body {
 // Modals
 .modal {
   color: $dark;
-  border-radius: unset;
 }
 
 // Lose the rounding on buttons

--- a/socialhome/static/sass/content.scss
+++ b/socialhome/static/sass/content.scss
@@ -34,6 +34,11 @@ a.opengraph-card {
   img {
     max-width: 100%;
   }
+
+  .modal-content {
+    border-radius: unset;
+  }
+
   #content-profile-pic {
     max-width: 50px;
     max-height: 50px;

--- a/socialhome/static/sass/content.scss
+++ b/socialhome/static/sass/content.scss
@@ -28,8 +28,9 @@ a.opengraph-card {
   }
 }
 
-#content-modal, #content-detail {
+#content-modal {
   overflow-wrap: break-word;
+  color: $dark;
 
   img {
     max-width: 100%;
@@ -48,25 +49,10 @@ a.opengraph-card {
     display: inline;
     padding-left: 20px;
   }
-}
 
-// Modal type styling for content-detail
-#content-detail {
-  background-color: $white;
-  color: $dark;
-
-  #content-header {
+  .content-bar {
+    font-size: smaller;
+    opacity: 0.5;
     padding: 15px;
-    border-bottom: 1px solid #e5e5e5;
-  }
-
-  #content-body {
-    padding: 15px;
-  }
-
-  #content-footer {
-    padding: 15px;
-    text-align: right;
-    border-top: 1px solid #e5e5e5;
   }
 }

--- a/socialhome/static/sass/content.scss
+++ b/socialhome/static/sass/content.scss
@@ -1,4 +1,6 @@
-.markdownx-preview, .grid-item, #content-modal-body {
+@import "variables";
+
+.markdownx-preview, .grid-item, #content-body {
   // Apply Bootstrap blockquote styling except for font-size change
   blockquote {
     padding: .5rem 1rem;
@@ -26,20 +28,40 @@ a.opengraph-card {
   }
 }
 
-#content-modal {
+#content-modal, #content-detail {
   overflow-wrap: break-word;
 
   img {
     max-width: 100%;
-
-    #content-modal-profile-pic {
-      max-width: 50px;
-      max-height: 50px;
-    }
+  }
+  #content-profile-pic {
+    max-width: 50px;
+    max-height: 50px;
   }
 
-  #content-modal-title {
+  #content-title {
     display: inline;
     padding-left: 20px;
+  }
+}
+
+// Modal type styling for content-detail
+#content-detail {
+  background-color: $white;
+  color: $dark;
+
+  #content-header {
+    padding: 15px;
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  #content-body {
+    padding: 15px;
+  }
+
+  #content-footer {
+    padding: 15px;
+    text-align: right;
+    border-top: 1px solid #e5e5e5;
   }
 }

--- a/socialhome/static/sass/content.scss
+++ b/socialhome/static/sass/content.scss
@@ -54,5 +54,15 @@ a.opengraph-card {
     font-size: smaller;
     opacity: 0.5;
     padding: 15px;
+
+    @media all and (max-width: $largeDevice) {
+      font-size: small;
+    }
+    @media all and (max-width: $mediumDevice) {
+      font-size: medium;
+    }
+    @media all and (max-width: $bsSmallDevice) {
+      font-size: large;
+    }
   }
 }

--- a/socialhome/static/sass/grids.scss
+++ b/socialhome/static/sass/grids.scss
@@ -9,6 +9,16 @@
     font-size: smaller;
     opacity: 0.5;
 
+    @media all and (max-width: $largeDevice) {
+      font-size: small;
+    }
+    @media all and (max-width: $mediumDevice) {
+      font-size: medium;
+    }
+    @media all and (max-width: $bsSmallDevice) {
+      font-size: large;
+    }
+
     .grid-item-open-action {
       text-decoration: none;
       cursor: pointer;

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -50,21 +50,5 @@
 {% endblock content %}
 
 {% block modal %}
-    <div class="modal" id="content-modal">
-        <div class="modal-dialog modal-lg" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <img src="" id="content-profile-pic">
-                    <h5 id="content-title" class="modal-title"></h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="{% trans "Close" %}">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div id="content-body" class="modal-body"></div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include "content/_content_detail.html" with modal=True content=None %}
 {% endblock %}

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -3,6 +3,14 @@
 
 {% block containertype %}container-fluid{% endblock %}
 
+{% block ogtags %}
+    <meta property="og:title" content="{% block stream_title %}{% endblock %} - {{ request.site.name }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://{{ request.site.domain }}{{ request.path }}" />
+    {# TODO fix logo #}
+    <meta property="og:image" content="https://socialhome.network/media/markdownx/74b37fa1-88d0-4e29-9fdc-8d07ba216f63.png" />
+{% endblock %}
+
 {% block content %}
     <script>var socialhomeStream = "{{ stream_name }}";</script>
     <div class="streams-container">

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -26,7 +26,7 @@
                         <div class="grid-item">
                             {{ content.rendered|safe }}
                             <div class="grid-item-bar">
-                                <span class="grid-item-open-action" data-content-id="{{ content.id }}" title="{{ content.formatted_timestamp }}">{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}</span>
+                                <span class="grid-item-open-action" data-content-guid="{{ content.guid }}" title="{{ content.formatted_timestamp }}">{{ content.humanized_timestamp }}{% if content.edited %} ({% trans "edited" %}){% endif %}</span>
                                 {% if content.author == request.user.profile %}
                                     &nbsp;
                                     <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -46,13 +46,13 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <img src="" id="content-modal-profile-pic">
-                    <h5 id="content-modal-title" class="modal-title"></h5>
+                    <img src="" id="content-profile-pic">
+                    <h5 id="content-title" class="modal-title"></h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="{% trans "Close" %}">
                         <span aria-hidden="true">&times;</span>
                     </button>
                 </div>
-                <div id="content-modal-body" class="modal-body"></div>
+                <div id="content-body" class="modal-body"></div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">{% trans "Close" %}</button>
                 </div>

--- a/socialhome/streams/templates/streams/profile.html
+++ b/socialhome/streams/templates/streams/profile.html
@@ -7,6 +7,8 @@
     <h2>{% if profile.name %}{{ profile.name }}{% else %}{{ profile.guid }}{% endif %}</h2>
 {% endblock %}
 
+{% block stream_title %}{% if profile.name %}{{ profile.name }}{% else %}{{ profile.guid }}{% endif %}{% endblock %}
+
 {% block stream_actions %}
     {% if profile == request.user.profile %}
         <div class="stamped">

--- a/socialhome/streams/templates/streams/public.html
+++ b/socialhome/streams/templates/streams/public.html
@@ -7,3 +7,5 @@
     <h2>{% trans "Public" %}</h2>
     <p>{% trans "Contains public content from around the network." %}</p>
 {% endblock %}
+
+{% block stream_title %}{% trans "Public" %}{% endblock %}

--- a/socialhome/streams/templates/streams/tag.html
+++ b/socialhome/streams/templates/streams/tag.html
@@ -5,3 +5,5 @@
 {% block stream_description %}
     <h2>#{{ tag_name }}</h2>
 {% endblock %}
+
+{% block stream_title %}#{{ tag_name }}{% endblock %}

--- a/socialhome/streams/templates/streams/tests/mocha.html
+++ b/socialhome/streams/templates/streams/tests/mocha.html
@@ -25,14 +25,14 @@
                 <div class="grid-item">
                     <p>Foo Bar</p>
                     <div class="grid-item-bar">
-                        <span class="grid-item-open-action" data-content-id="1" title="2017-03-14 22:04:00+00:00">2 hours ago</span>
+                        <span class="grid-item-open-action" data-content-guid="1234" title="2017-03-14 22:04:00+00:00">2 hours ago</span>
                     </div>
                 </div>
                 <div class="grid-item">
                     <p>#nsfw</p>
                     <p><img id="nsfw-content" class="nsfw" src="{% static "images/pony100.png" %}"></p>
                     <div class="grid-item-bar">
-                        <span class="grid-item-open-action" data-content-id="2" title="2017-03-14 21:04:00+00:00">3 hours ago (edited)</span>
+                        <span class="grid-item-open-action" data-content-guid="2345" title="2017-03-14 21:04:00+00:00">3 hours ago (edited)</span>
                     </div>
                 </div>
             </div>

--- a/socialhome/streams/templates/streams/tests/mocha.html
+++ b/socialhome/streams/templates/streams/tests/mocha.html
@@ -42,13 +42,21 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <img src="" id="content-modal-profile-pic">
-                    <h5 id="content-modal-title" class="modal-title"></h5>
+                    <img src="" id="content-profile-pic">
+                    <h5 id="content-title" class="modal-title"></h5>
                     <button type="button" class="close" data-dismiss="modal">
                         <span>&times;</span>
                     </button>
                 </div>
-                <div id="content-modal-body" class="modal-body"></div>
+                <div id="content-body" class="modal-body"></div>
+                <div class="content-bar">
+                    <span id="content-timestamp" title=""></span>
+                    <span id="content-bar-actions" class="hidden">
+                        &nbsp;
+                        <a id="content-update-link" href=""><i class="fa fa-pencil" title="Update" aria-label="Update"></i></a>
+                        <a id="content-delete-link" href=""><i class="fa fa-remove" title="Delete" aria-label="Delete"></i></a>
+                    </span>
+                </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 </div>

--- a/socialhome/streams/tests/test_consumers.py
+++ b/socialhome/streams/tests/test_consumers.py
@@ -36,6 +36,7 @@ class TestStreamConsumerReceive(ChannelTestCase):
         self.assertEqual(text["contents"], [
             {
                 "id": self.content.id,
+                "guid": self.content.guid,
                 "author": self.content.author.id,
                 "rendered": self.content.rendered,
                 "humanized_timestamp": self.content.humanized_timestamp,

--- a/socialhome/templates/base.html
+++ b/socialhome/templates/base.html
@@ -4,6 +4,13 @@
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
     <title>{% block title %}{{ request.site.name }}{% endblock title %}</title>
+    {% block ogtags %}
+        <meta property="og:title" content="{{ request.site.name }}" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://{{ request.site.domain }}" />
+        {# TODO fix logo #}
+        <meta property="og:image" content="https://socialhome.network/media/markdownx/74b37fa1-88d0-4e29-9fdc-8d07ba216f63.png" />
+    {% endblock %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="">
     <meta name="author" content="">

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -38,7 +38,7 @@ class ProfileDetailView(AccessMixin, DetailView):
         Limit by content visibility.
         """
         contents = Content.objects.filter(pinned=True, author=self.object)
-        if not self.request.user.is_authenticated():
+        if not self.request.user.is_authenticated:
             contents = contents.filter(visibility=Visibility.PUBLIC)
         elif self.request.user.profile != self.target_profile:
             # TODO: filter out also LIMITED until contacts implemented
@@ -53,7 +53,7 @@ class ProfileDetailView(AccessMixin, DetailView):
         self.target_profile = get_object_or_404(Profile, guid=self.kwargs.get("guid"))
         if self.target_profile.visibility == Visibility.PUBLIC:
             return super(ProfileDetailView, self).dispatch(request, *args, **kwargs)
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             if self.target_profile.visibility == Visibility.SITE:
                 return super(ProfileDetailView, self).dispatch(request, *args, **kwargs)
             # TODO: handle Visibility.LIMITED once contacts are implemented


### PR DESCRIPTION
Add a content view. When clicking timestamp on stream, content modal opens up. Direct url opens up a dedicated page for the content.

TODO
* [x] Tests
* [x] Refactor content detail route to `domain.tld/content/<id>/<slug_generated_from_content>`
* [x] Ensure `Content.slug` doesn't end up empty due to fully unicode posts which Django generates an empty slug for.

Closes #21 