### PR TITLE
Add possibility to follow/unfollow users

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -107,6 +107,7 @@ module.exports = function (grunt) {
                     "<%= paths.bower %>/imagesloaded/imagesloaded.pkgd.min.js",
                     "<%= paths.bower %>/reconnecting-websocket/reconnecting-websocket.min.js",
                     "<%= paths.bower %>/bootstrap-markdown/js/bootstrap-markdown.js",
+                    "<%= paths.bower %>/js-cookie/src/js.cookie.js",
                     "<%= paths.js %>/vendor/appear.min.js",
                     "<%= paths.js %>/content.js",
                     "<%= paths.js %>/grids.js",

--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,8 @@
     "jquery-ui": "jqueryui#^1.12.1",
     "reconnecting-websocket": "https://github.com/joewalnes/reconnecting-websocket.git#1.0.0",
     "underscore": "^1.8.3",
-    "bootstrap-markdown": "2.10.0"
+    "bootstrap-markdown": "2.10.0",
+    "js-cookie": "^2.1.4"
   },
   "devDependencies": {
     "sinon": "http://sinonjs.org/releases/sinon-1.17.4.js",

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -105,7 +105,6 @@ MANAGERS = ADMINS
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
-    # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
     "default": env.db("DATABASE_URL", default="postgres:///socialhome"),
 }
 DATABASES["default"]["ATOMIC_REQUESTS"] = True

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -99,11 +99,6 @@ TEMPLATES[0]['OPTIONS']['loaders'] = [
         'django.template.loaders.filesystem.Loader', 'django.template.loaders.app_directories.Loader', ]),
 ]
 
-# DATABASE CONFIGURATION
-# ------------------------------------------------------------------------------
-# Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
-DATABASES['default'] = env.db("DATABASE_URL")
-
 # CACHING
 # ------------------------------------------------------------------------------
 CACHES = {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,9 +52,9 @@ django-rq==0.9.5
 django-extensions==1.7.9
 
 # Federation
-federation==0.12.0
+#federation==0.12.0
 # for quick overriding a commit version
-#git+https://github.com/jaywink/federation.git@d64a2c27a2da7b9e0e92ae6d940f45e159947f07#egg=federation==0.11.1
+git+https://github.com/jaywink/federation.git@78d344d6a8b25c29f65b85d8cd0a5969fd8050f2#egg=federation==0.12.0.1
 
 # Content
 django-markdownx==2.0.21

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -277,6 +277,7 @@ class Content(models.Model):
         humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
         is_author = bool(user.is_authenticated and self.author == user.profile)
         is_following_author = bool(user.is_authenticated and self.author_id in user.profile.following_ids)
+        profile_id = user.profile.id if getattr(user, "profile", None) else ""
         return {
             "id": self.id,
             "guid": self.guid,
@@ -300,7 +301,7 @@ class Content(models.Model):
             "update_url": reverse("content:update", kwargs={"pk": self.id}) if is_author else "",
             "delete_url": reverse("content:delete", kwargs={"pk": self.id}) if is_author else "",
             "reply_url": reverse("content:reply", kwargs={"pk": self.id}) if user.is_authenticated else "",
-            "user_id": user.profile.id,
+            "profile_id": profile_id,
         }
 
     def visible_for_user(self, user):

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -276,6 +276,7 @@ class Content(models.Model):
     def dict_for_view(self, user):
         humanized_timestamp = "%s (edited)" % self.humanized_timestamp if self.edited else self.humanized_timestamp
         is_author = bool(user.is_authenticated and self.author == user.profile)
+        is_following_author = bool(user.is_authenticated and self.author_id in user.profile.following_ids)
         return {
             "id": self.id,
             "guid": self.guid,
@@ -293,11 +294,13 @@ class Content(models.Model):
             "child_count": self.children.count(),
             "parent": self.parent_id if self.parent else "",
             "is_author": is_author,
+            "is_following_author": is_following_author,
             "is_authenticated": bool(user.is_authenticated),
             "slug": self.slug,
             "update_url": reverse("content:update", kwargs={"pk": self.id}) if is_author else "",
             "delete_url": reverse("content:delete", kwargs={"pk": self.id}) if is_author else "",
             "reply_url": reverse("content:reply", kwargs={"pk": self.id}) if user.is_authenticated else "",
+            "user_id": user.profile.id,
         }
 
     def visible_for_user(self, user):

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -11,16 +11,16 @@
                 {% endif %}
                 <img src="{% if content %}{{ content.author.image_url_small }}{% endif %}" id="content-profile-pic">
                 <h5 id="content-title" class="modal-title">{% if content %}{{ content.author.name }} &lt;{{ content.author.handle }}&gt;{% endif %}</h5>
-                <div>
-                    <a href="{% if content %}{{ content.author.get_absolute_url }}{% endif %}" class="btn btn-default" title="{% trans "Profile" %}" aria-label="{% trans "Profile" %}"><i class="fa fa-user"></i></a>
+                <div class="pull-right">
+                    <a href="{% if content %}{{ content.author.get_absolute_url }}{% endif %}" class="btn btn-secondary" title="{% trans "Profile" %}" aria-label="{% trans "Profile" %}"><i class="fa fa-user"></i></a>
                     {% if content and not content.author.user %}
-                        <a href="{{ content.author.home_url }}" class="btn btn-default" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
+                        <a href="{{ content.author.home_url }}" class="btn btn-secondary" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
                     {% endif %}
                     {# Note, following intentionally not in modal as plan is to likely remove modal #}
                     {% if content %}
                         {% if request.user.is_authenticated and content.author != request.user.profile %}
-                            <button class="follower-button btn btn-default {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
-                            <button class="follower-button btn btn-default {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                            <button class="follower-button btn btn-secondary {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
+                            <button class="follower-button btn btn-secondary {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
                         {% endif %}
                     {% endif %}
                 </div>

--- a/socialhome/content/templates/content/_content_detail.html
+++ b/socialhome/content/templates/content/_content_detail.html
@@ -16,6 +16,13 @@
                     {% if content and not content.author.user %}
                         <a href="{{ content.author.home_url }}" class="btn btn-default" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
                     {% endif %}
+                    {# Note, following intentionally not in modal as plan is to likely remove modal #}
+                    {% if content %}
+                        {% if request.user.is_authenticated and content.author != request.user.profile %}
+                            <button class="follower-button btn btn-default {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
+                            <button class="follower-button btn btn-default {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                        {% endif %}
+                    {% endif %}
                 </div>
             </div>
             <div id="content-body" class="modal-body" {% if content %}data-content-id="{{ content.id }}"{% endif %}>

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -1,6 +1,5 @@
-from unittest.mock import Mock
-
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.client import Client
@@ -15,7 +14,7 @@ from socialhome.users.tests.factories import UserFactory
 
 
 @pytest.mark.usefixtures("db")
-class TestRootProfile(object):
+class TestRootProfile:
     @pytest.mark.usefixtures("client", "settings")
     def test_home_view_rendered_without_root_profile(self, client, settings):
         settings.SOCIALHOME_ROOT_PROFILE = None
@@ -40,7 +39,7 @@ class TestRootProfile(object):
 
 
 @pytest.mark.usefixtures("admin_client", "rf")
-class TestContentCreateView(object):
+class TestContentCreateView:
     def _get_request_and_view(self, rf):
         request = rf.get("/")
         request.user = UserFactory()
@@ -75,7 +74,7 @@ class TestContentCreateView(object):
 
 
 @pytest.mark.usefixtures("admin_client", "rf")
-class TestContentUpdateView(object):
+class TestContentUpdateView:
     def _get_request_view_and_content(self, rf):
         request = rf.get("/")
         request.user = UserFactory()
@@ -145,7 +144,7 @@ class TestContentUpdateView(object):
 
 
 @pytest.mark.usefixtures("admin_client", "rf")
-class TestContentDeleteView(object):
+class TestContentDeleteView:
     def _get_request_view_and_content(self, rf):
         request = rf.get("/")
         request.user = UserFactory()
@@ -181,6 +180,8 @@ class TestContentDeleteView(object):
 
 
 class TestContentView(TestCase):
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -194,7 +195,7 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.content.dict_for_view(Mock(is_authenticated=False)), response.json())
+        self.assertEqual(self.content.dict_for_view(AnonymousUser()), response.json())
 
     def test_content_view_by_guid_renders_json_result(self):
         response = self.client.get(
@@ -202,7 +203,7 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.content.dict_for_view(Mock(is_authenticated=False)), response.json())
+        self.assertEqual(self.content.dict_for_view(AnonymousUser()), response.json())
 
     def test_content_view_by_slug_renders_json_result(self):
         response = self.client.get(
@@ -210,7 +211,7 @@ class TestContentView(TestCase):
             HTTP_X_REQUESTED_WITH="XMLHttpRequest"
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(self.content.dict_for_view(Mock(is_authenticated=False)), response.json())
+        self.assertEqual(self.content.dict_for_view(AnonymousUser()), response.json())
 
     def test_content_view_redirects_to_login_for_private_content_except_if_owned(self):
         self.client.force_login(self.content.author.user)
@@ -268,7 +269,6 @@ class TestContentView(TestCase):
         self.assertNotContains(response, '<span id="content-bar-actions" class="hidden"')
 
 
-@pytest.mark.usefixtures("db")
 class TestContentReplyView(TestCase):
     @classmethod
     def setUpTestData(cls):

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -163,7 +163,7 @@ def forward_relayable(entity, parent_id):
     handle_send(entity, parent.author, recipients)
 
 
-def send_follow(profile_id, followed_id):
+def send_follow_change(profile_id, followed_id, follow):
     """Handle sending of a local follow of a remote profile."""
     try:
         profile = Profile.objects.get(id=profile_id, user__isnull=False)
@@ -178,7 +178,7 @@ def send_follow(profile_id, followed_id):
     if settings.DEBUG:
         # Don't send in development mode
         return
-    entity = base.Follow(handle=profile.handle, target_handle=remote_profile.handle)
+    entity = base.Follow(handle=profile.handle, target_handle=remote_profile.handle, following=follow)
     # TODO: add high level method support to federation for private payload delivery
     payload = handle_create_payload(entity, profile, to_user=remote_profile)
     url = "https://%s/receive/users/%s" % (

--- a/socialhome/federate/tests/test_tasks.py
+++ b/socialhome/federate/tests/test_tasks.py
@@ -12,7 +12,7 @@ from socialhome.enums import Visibility
 from socialhome.federate.tasks import (
     receive_task, send_content, send_content_retraction, send_reply,
     forward_relayable, _get_remote_followers,
-    send_follow)
+    send_follow_change)
 from socialhome.users.models import Profile
 from socialhome.users.tests.factories import UserFactory, ProfileFactory
 
@@ -181,8 +181,8 @@ class TestSendFollow(TestCase):
 
     @patch("socialhome.federate.tasks.handle_create_payload", return_value="payload")
     @patch("socialhome.federate.tasks.send_document")
-    def test_send_follow(self, mock_send, mock_payload):
-        send_follow(self.profile.id, self.remote_profile.id)
+    def test_send_follow_change(self, mock_send, mock_payload):
+        send_follow_change(self.profile.id, self.remote_profile.id, True)
         mock_send.assert_called_once_with(
             "https://%s/receive/users/%s" % (self.remote_profile.handle.split("@")[1], self.remote_profile.guid),
             "payload",

--- a/socialhome/federate/utils/tasks.py
+++ b/socialhome/federate/utils/tasks.py
@@ -251,14 +251,18 @@ def sender_key_fetcher(handle):
     :returns: RSA public key or None
     :rtype: str
     """
+    logging.debug("sender_key_fetcher - Checking for handle '%s'", handle)
     try:
         profile = Profile.objects.get(handle=handle, user__isnull=True)
+        logging.debug("sender_key_fetcher - Handle %s already exists as a profile", handle)
     except Profile.DoesNotExist:
+        logging.debug("sender_key_fetcher - Handle %s was not found, fetching from remote", handle)
         remote_profile = retrieve_remote_profile(handle)
         if not remote_profile:
             logger.warning("Remote profile %s for sender key not found locally or remotely.", handle)
             return None
         # We might as well create the profile locally here since we'll need it again soon
+        logging.debug("sender_key_fetcher - Creating %s from remote profile", handle)
         Profile.from_remote_profile(remote_profile)
         return remote_profile.public_key
     else:

--- a/socialhome/notifications/tasks.py
+++ b/socialhome/notifications/tasks.py
@@ -59,6 +59,7 @@ def send_follow_notification(follower_id, followed_id):
     except Profile.DoesNotExist:
         logger.warning("No follower profile %s found for follow notifications", follower_id)
         return
+    logger.info("send_follow_notification - Sending mail to %s", user.email)
     send_mail(
         "%sNew follower" % settings.EMAIL_SUBJECT_PREFIX,
         "You have a new follower: %s" % follower.handle,

--- a/socialhome/static/js/content.js
+++ b/socialhome/static/js/content.js
@@ -16,8 +16,8 @@
                             '<a href="<%= content.author_home_url %>" class="btn btn-default" title="' + gettext("Home") + '" aria-label="' + gettext("Home") + '"><i class="fa fa-home"></i></a>' +
                         '<% } %>' +
                         '<% if (content.is_authenticated && ! content.is_author) { %>' +
-                            '<button class="follower-button btn btn-default <% if (! content.is_following_author) { %>hidden<% } %>" data-action="remove_follower" data-profileid="<%= content.user_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Unfollow") + '" aria-label="' + gettext("Unfollow") + '"><i class="fa fa-minus"></i></button>' +
-                            '<button class="follower-button btn btn-default <% if (content.is_following_author) { %>hidden<% } %>" data-action="add_follower" data-profileid="<%= content.user_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Follow") + '" aria-label="' + gettext("Follow") + '"><i class="fa fa-plus"></i></button>' +
+                            '<button class="follower-button btn btn-default <% if (! content.is_following_author) { %>hidden<% } %>" data-action="remove_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Unfollow") + '" aria-label="' + gettext("Unfollow") + '"><i class="fa fa-minus"></i></button>' +
+                            '<button class="follower-button btn btn-default <% if (content.is_following_author) { %>hidden<% } %>" data-action="add_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Follow") + '" aria-label="' + gettext("Follow") + '"><i class="fa fa-plus"></i></button>' +
                         '<% } %>' +
                     '</div>' +
                 '</div>' +

--- a/socialhome/static/js/content.js
+++ b/socialhome/static/js/content.js
@@ -6,7 +6,7 @@
             '<%= content.rendered %>' +
             '<% if (content.parent || stream !== "profile") { %>' +
                 '<div class="grid-item-author-bar">' +
-                    '<div class="profile-box-trigger"' +
+                    '<div class="profile-box-trigger">' +
                         '<img src="<%= content.author_image %>" class="grid-item-author-bar-pic"> <%= content.author_name %>' +
                     '</div>' +
                     '<div class="profile-box hidden">' +

--- a/socialhome/static/js/content.js
+++ b/socialhome/static/js/content.js
@@ -11,14 +11,16 @@
                     '</div>' +
                     '<div class="profile-box hidden">' +
                         '<%= content.author_handle %>' +
-                        '<a href="<%= content.author_profile_url %>" class="btn btn-default" title="' + gettext("Profile") + '" aria-label="' + gettext("Profile") + '"><i class="fa fa-user"></i></a>' +
-                        '<% if (! content.author_is_local) { %>' +
-                            '<a href="<%= content.author_home_url %>" class="btn btn-default" title="' + gettext("Home") + '" aria-label="' + gettext("Home") + '"><i class="fa fa-home"></i></a>' +
-                        '<% } %>' +
-                        '<% if (content.is_authenticated && ! content.is_author) { %>' +
-                            '<button class="follower-button btn btn-default <% if (! content.is_following_author) { %>hidden<% } %>" data-action="remove_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Unfollow") + '" aria-label="' + gettext("Unfollow") + '"><i class="fa fa-minus"></i></button>' +
-                            '<button class="follower-button btn btn-default <% if (content.is_following_author) { %>hidden<% } %>" data-action="add_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Follow") + '" aria-label="' + gettext("Follow") + '"><i class="fa fa-plus"></i></button>' +
-                        '<% } %>' +
+                        '<div class="pull-right">' +
+                            '<a href="<%= content.author_profile_url %>" class="btn btn-secondary" title="' + gettext("Profile") + '" aria-label="' + gettext("Profile") + '"><i class="fa fa-user"></i></a>' +
+                            '<% if (! content.author_is_local) { %>' +
+                                '<a href="<%= content.author_home_url %>" class="btn btn-secondary" title="' + gettext("Home") + '" aria-label="' + gettext("Home") + '"><i class="fa fa-home"></i></a>' +
+                            '<% } %>' +
+                            '<% if (content.is_authenticated && ! content.is_author) { %>' +
+                                '<button class="follower-button btn btn-secondary <% if (! content.is_following_author) { %>hidden<% } %>" data-action="remove_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Unfollow") + '" aria-label="' + gettext("Unfollow") + '"><i class="fa fa-minus"></i></button>' +
+                                '<button class="follower-button btn btn-secondary <% if (content.is_following_author) { %>hidden<% } %>" data-action="add_follower" data-profileid="<%= content.profile_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Follow") + '" aria-label="' + gettext("Follow") + '"><i class="fa fa-plus"></i></button>' +
+                            '<% } %>' +
+                        '</div>' +
                     '</div>' +
                 '</div>' +
             '<% } %>' +

--- a/socialhome/static/js/content.js
+++ b/socialhome/static/js/content.js
@@ -15,6 +15,10 @@
                         '<% if (! content.author_is_local) { %>' +
                             '<a href="<%= content.author_home_url %>" class="btn btn-default" title="' + gettext("Home") + '" aria-label="' + gettext("Home") + '"><i class="fa fa-home"></i></a>' +
                         '<% } %>' +
+                        '<% if (content.is_authenticated && ! content.is_author) { %>' +
+                            '<button class="follower-button btn btn-default <% if (! content.is_following_author) { %>hidden<% } %>" data-action="remove_follower" data-profileid="<%= content.user_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Unfollow") + '" aria-label="' + gettext("Unfollow") + '"><i class="fa fa-minus"></i></button>' +
+                            '<button class="follower-button btn btn-default <% if (content.is_following_author) { %>hidden<% } %>" data-action="add_follower" data-profileid="<%= content.user_id %>" data-target="<%= content.author_guid %>" title="' + gettext("Follow") + '" aria-label="' + gettext("Follow") + '"><i class="fa fa-plus"></i></button>' +
+                        '<% } %>' +
                     '</div>' +
                 '</div>' +
             '<% } %>' +

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -255,12 +255,12 @@ $(function () {
                     if (!controller.isContentDetail()) {
                         controller.addContentListeners();
                         controller.addReplyTriggers();
-                        controller.initProfileBoxTriggers();
-                        controller.addFollowUnfollowTriggers();
                         if (ids.length && data.placement === "appended") {
                             controller.addLoadMoreTrigger();
                         }
                     }
+                    controller.initProfileBoxTriggers();
+                    controller.addFollowUnfollowTriggers();
                 });
                 view.contentIds = _.union(view.contentIds, ids);
             }

--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -186,6 +186,7 @@ $(function () {
             this.addContentListeners();
             this.addReplyTriggers();
             this.initProfileBoxTriggers();
+            this.addFollowUnfollowTriggers();
             view.addNSFWShield();
             this.socket = this.createConnection();
             this.socket.onmessage = this.handleMessage;
@@ -255,6 +256,7 @@ $(function () {
                         controller.addContentListeners();
                         controller.addReplyTriggers();
                         controller.initProfileBoxTriggers();
+                        controller.addFollowUnfollowTriggers();
                         if (ids.length && data.placement === "appended") {
                             controller.addLoadMoreTrigger();
                         }
@@ -344,6 +346,23 @@ $(function () {
                 $(ev.currentTarget).next().toggleClass("hidden");
                 $('.grid').masonry("layout");
             });
+        },
+
+        followUnfollow: function(ev) {
+            var $elem = $(ev.currentTarget);
+            var targetGuid = $elem.data("target");
+            $.post({
+                url: "/api/profiles/" +$elem.data("profileid") + "/" + $elem.data("action") + "/",
+                data: { guid: targetGuid },
+                success: function () {
+                    $(".follower-button[data-target='" + targetGuid + "']").toggleClass("hidden");
+                },
+                headers: { "X-CSRFToken": Cookies.get('csrftoken') },
+            });
+        },
+
+        addFollowUnfollowTriggers: function() {
+            $(".follower-button").off("click", controller.followUnfollow).click(controller.followUnfollow);
         },
     };
 

--- a/socialhome/static/js/tests/test_streams.js
+++ b/socialhome/static/js/tests/test_streams.js
@@ -79,7 +79,7 @@ describe("Streams", function() {
                         id: 4, rendered: "adds new content", humanized_timestamp: "2 minutes ago",
                         formatted_timestamp: "2017-01-02 10:11:12+00:00",
                         author_image: "http://localhost/foobar.png", author_name: "Some Author",
-                        parent_id: "",
+                        parent_id: "", profile_id: "",
                     }],
                     placement: "prepended",
                 };
@@ -281,7 +281,7 @@ describe("Streams", function() {
                     id: 3, rendered: "new reply", humanized_timestamp: "2 minutes ago",
                     formatted_timestamp: "2017-01-02 10:11:12+00:00",
                     author_image: "http://localhost/foobar.png", author_name: "Some Author",
-                    parent: "1",
+                    parent: "1", profile_id: "2"
                 }],
                 placement: "children",
                 parent_id: 1,

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -44,6 +44,10 @@
                                         {% if not content.author.user %}
                                             <a href="{{ content.author.home_url }}" class="btn btn-default" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
                                         {% endif %}
+                                        {% if request.user.is_authenticated and content.author != request.user.profile %}
+                                            <button class="follower-button btn btn-default {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
+                                            <button class="follower-button btn btn-default {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                                        {% endif %}
                                     </div>
                                 </div>
                             {% endif %}

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -40,14 +40,16 @@
                                     </div>
                                     <div class="profile-box hidden">
                                         {{ content.author.handle }}
-                                        <a href="{{ content.author.get_absolute_url }}" class="btn btn-default" title="{% trans "Profile" %}" aria-label="{% trans "Profile" %}"><i class="fa fa-user"></i></a>
-                                        {% if not content.author.user %}
-                                            <a href="{{ content.author.home_url }}" class="btn btn-default" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
-                                        {% endif %}
-                                        {% if request.user.is_authenticated and content.author != request.user.profile %}
-                                            <button class="follower-button btn btn-default {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
-                                            <button class="follower-button btn btn-default {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
-                                        {% endif %}
+                                        <div class="pull-right">
+                                            <a href="{{ content.author.get_absolute_url }}" class="btn btn-secondary" title="{% trans "Profile" %}" aria-label="{% trans "Profile" %}"><i class="fa fa-user"></i></a>
+                                            {% if not content.author.user %}
+                                                <a href="{{ content.author.home_url }}" class="btn btn-secondary" title="{% trans "Home" %}" aria-label="{% trans "Home" %}"><i class="fa fa-home"></i></a>
+                                            {% endif %}
+                                            {% if request.user.is_authenticated and content.author != request.user.profile %}
+                                                <button class="follower-button btn btn-secondary {% if not content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
+                                                <button class="follower-button btn btn-secondary {% if content.author.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ content.author.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                                            {% endif %}
+                                        </div>
                                     </div>
                                 </div>
                             {% endif %}

--- a/socialhome/streams/templates/streams/tests/mocha.html
+++ b/socialhome/streams/templates/streams/tests/mocha.html
@@ -25,7 +25,9 @@
                 <div class="grid-item" data-content-id="1">
                     <p>Foo Bar</p>
                     <div class="grid-item-author-bar">
-                        <img src="{% static "images/pony100.png" %}" class="grid-item-author-bar-pic"> Dummy Author
+                        <div class="profile-box-trigger">
+                            <img src="{% static "images/pony100.png" %}" class="grid-item-author-bar-pic"> Dummy Author
+                        </div>
                     </div>
                     <div class="grid-item-bar">
                         <div class="row">
@@ -51,7 +53,9 @@
                     <p>#nsfw<</p>
                     <p><img id="nsfw-content" class="nsfw" src="{% static "images/pony100.png" %}"></p>
                     <div class="grid-item-author-bar">
-                        <img src="{% static "images/pony100.png" %}" class="grid-item-author-bar-pic"> Dummy Author
+                        <div class="profile-box-trigger">
+                            <img src="{% static "images/pony100.png" %}" class="grid-item-author-bar-pic"> Dummy Author
+                        </div>
                     </div>
                     <div class="grid-item-bar">
                         <div class="row">

--- a/socialhome/streams/tests/test_views.py
+++ b/socialhome/streams/tests/test_views.py
@@ -1,38 +1,47 @@
-import pytest
 from django.core.urlresolvers import reverse
 from django.test import Client, TestCase
 
 from socialhome.content.tests.factories import ContentFactory, TagFactory
 from socialhome.enums import Visibility
+from socialhome.users.tests.factories import UserFactory
 
 
-@pytest.mark.usefixtures("db", "client")
-class TestPublicStreamView(object):
-    def test_renders_without_content(self, client):
-        response = client.get(reverse("streams:public"))
+class TestPublicStreamView(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.content = ContentFactory(visibility=Visibility.PUBLIC)
+        cls.site = ContentFactory(visibility=Visibility.SITE)
+        cls.selff = ContentFactory(visibility=Visibility.SELF)
+        cls.limited = ContentFactory(visibility=Visibility.LIMITED)
+        cls.user = UserFactory()
+        cls.client = Client()
+
+    def test_renders_without_content(self):
+        response = self.client.get(reverse("streams:public"))
         assert response.status_code == 200
 
-    def test_renders_with_content(self, client):
-        content = ContentFactory(visibility=Visibility.PUBLIC)
-        response = client.get(reverse("streams:public"))
+    def test_renders_with_content(self):
+        response = self.client.get(reverse("streams:public"))
         assert response.status_code == 200
-        assert content.text in str(response.content)
+        assert self.content.text in str(response.content)
 
-    def test_uses_correct_template(self, client):
-        response = client.get(reverse("streams:public"))
+    def test_uses_correct_template(self):
+        response = self.client.get(reverse("streams:public"))
         template_names = [template.name for template in response.templates]
         assert "streams/public.html" in template_names
 
-    def test_contains_only_public_content(self, client):
-        content = ContentFactory(visibility=Visibility.PUBLIC)
-        site = ContentFactory(visibility=Visibility.SITE)
-        selff = ContentFactory(visibility=Visibility.SELF)
-        limited = ContentFactory(visibility=Visibility.LIMITED)
-        response = client.get(reverse("streams:public"))
-        assert content.text in str(response.content)
-        assert site.text not in str(response.content)
-        assert selff.text not in str(response.content)
-        assert limited.text not in str(response.content)
+    def test_contains_only_public_content(self):
+        response = self.client.get(reverse("streams:public"))
+        assert self.content.text in str(response.content)
+        assert self.site.text not in str(response.content)
+        assert self.selff.text not in str(response.content)
+        assert self.limited.text not in str(response.content)
+
+    def test_logged_in_user(self):
+        self.client.force_login(self.user)
+        response = self.client.get(reverse("streams:public"))
+        assert response.status_code == 200
 
 
 class TestTagsStreamView(TestCase):

--- a/socialhome/tests/environment.py
+++ b/socialhome/tests/environment.py
@@ -1,0 +1,20 @@
+import requests
+from unittest.mock import Mock
+
+
+class MockResponse(str):
+    status_code = 200
+    text = ""
+
+    @staticmethod
+    def raise_for_status():
+        pass
+
+
+# Disable certain types of network calls from now on
+# This will not be 100% but it should work for those network calls we use
+requests.get = Mock(return_value=MockResponse)
+requests.post = Mock()
+requests.patch = Mock()
+requests.delete = Mock()
+requests.put = Mock()

--- a/socialhome/tests/test_environment.py
+++ b/socialhome/tests/test_environment.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+import requests
+
+from socialhome.tests.utils import SocialhomeTestCase
+
+
+class TestEnvironment(SocialhomeTestCase):
+    def test_requests_mocks(self):
+        self.assertTrue(isinstance(requests.get, Mock))
+        self.assertTrue(isinstance(requests.put, Mock))
+        self.assertTrue(isinstance(requests.post, Mock))
+        self.assertTrue(isinstance(requests.patch, Mock))
+        self.assertTrue(isinstance(requests.delete, Mock))

--- a/socialhome/tests/utils.py
+++ b/socialhome/tests/utils.py
@@ -1,6 +1,16 @@
 from unittest.mock import Mock
 
+from test_plus import TestCase
 
+import socialhome.tests.environment  # Set some environment tweaks
+
+
+class SocialhomeTestCase(TestCase):
+    maxDiff = None
+
+
+# py.test monkeypatches while we still have two kinds of tests
+# Remove these once all our tests are either `SocialhomeTestCase` or another test class
 def disable_requests(monkeypatch):
     """Mock away request.get and requests.post."""
     monkeypatch.setattr("requests.post", Mock())

--- a/socialhome/users/apps.py
+++ b/socialhome/users/apps.py
@@ -7,4 +7,4 @@ class UsersConfig(AppConfig):
 
     def ready(self):
         """Import our signals."""
-        from socialhome.users.signals import create_user_profile, send_follow_notification
+        from socialhome.users.signals import create_user_profile, profile_following_change

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import AbstractUser
 from django.core.urlresolvers import reverse
 from django.core.validators import validate_email
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 from enumfields import EnumIntegerField
 from model_utils.models import TimeStampedModel
@@ -120,7 +121,7 @@ class Profile(TimeStampedModel):
         self.rsa_private_key = key.exportKey()
         self.save(update_fields=("rsa_private_key", "rsa_public_key"))
 
-    @property
+    @cached_property
     def private_key(self):
         """Required by federation.
 
@@ -128,7 +129,7 @@ class Profile(TimeStampedModel):
         """
         return RSA.importKey(self.rsa_private_key)
 
-    @property
+    @cached_property
     def key(self):
         """Required by federation.
 
@@ -152,6 +153,10 @@ class Profile(TimeStampedModel):
                 self.handle.split("@")[1], self.image_url_small,
             )
         return self.image_url_small
+
+    @cached_property
+    def following_ids(self):
+        return self.following.values_list("id", flat=True)
 
     def visible_to_user(self, user):
         """Check whether the given user should be able to see this profile."""

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -197,15 +197,18 @@ class Profile(TimeStampedModel):
     @staticmethod
     def from_remote_profile(remote_profile):
         """Create a Profile from a remote Profile entity."""
-        return Profile.objects.create(
-            name=safe_text(remote_profile.name),
+        profile, _created = Profile.objects.update_or_create(
             guid=safe_text(remote_profile.guid),
-            handle=remote_profile.handle,
-            visibility=Visibility.PUBLIC if remote_profile.public else Visibility.LIMITED,
-            rsa_public_key=safe_text(remote_profile.public_key),
-            image_url_large=safe_text(remote_profile.image_urls["large"]),
-            image_url_medium=safe_text(remote_profile.image_urls["medium"]),
-            image_url_small=safe_text(remote_profile.image_urls["small"]),
-            location=safe_text(remote_profile.location),
-            email=remote_profile.email,
+            handle=safe_text(remote_profile.handle),
+            defaults={
+                "name": safe_text(remote_profile.name),
+                "visibility": Visibility.PUBLIC if remote_profile.public else Visibility.LIMITED,
+                "rsa_public_key": safe_text(remote_profile.public_key),
+                "image_url_large": safe_text(remote_profile.image_urls["large"]),
+                "image_url_medium": safe_text(remote_profile.image_urls["medium"]),
+                "image_url_small": safe_text(remote_profile.image_urls["small"]),
+                "location": safe_text(remote_profile.location),
+                "email": safe_text(remote_profile.email),
+            },
         )
+        return profile

--- a/socialhome/users/signals.py
+++ b/socialhome/users/signals.py
@@ -6,7 +6,7 @@ from django.db import transaction
 from django.db.models.signals import post_save, m2m_changed
 from django.dispatch import receiver
 
-from socialhome.federate.tasks import send_follow
+from socialhome.federate.tasks import send_follow_change
 from socialhome.notifications.tasks import send_follow_notification
 from socialhome.users.models import User, Profile
 
@@ -30,12 +30,15 @@ def create_user_profile(sender, **kwargs):
 @receiver(m2m_changed, sender=Profile.following.through)
 def profile_following_change(sender, instance, action, **kwargs):
     """Deliver notification on new followers."""
-    if action == "post_add":
+    if action in ["post_add", "post_remove"]:
         def on_commit():
             for id in kwargs.get("pk_set"):
-                django_rq.enqueue(send_follow_notification, instance.id, id)
-                # Send out on the federation layer if local follower, remote followed
+                if action == "post_add":
+                    django_rq.enqueue(send_follow_notification, instance.id, id)
+                # Send out on the federation layer if local follower, remote followed/unfollowed
                 if Profile.objects.filter(id=id, user__isnull=True).exists() and instance.user:
-                    django_rq.enqueue(send_follow, instance.id, id)
+                    django_rq.enqueue(
+                        send_follow_change, instance.id, id, True if action == "post_add" else False
+                    )
 
         transaction.on_commit(on_commit)

--- a/socialhome/users/signals.py
+++ b/socialhome/users/signals.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import django_rq
+import logging
 from django.conf import settings
 from django.db import transaction
 from django.db.models.signals import post_save, m2m_changed
@@ -9,6 +10,8 @@ from django.dispatch import receiver
 from socialhome.federate.tasks import send_follow_change
 from socialhome.notifications.tasks import send_follow_notification
 from socialhome.users.models import User, Profile
+
+logger = logging.getLogger("socialhome")
 
 
 @receiver(post_save, sender=User)
@@ -31,9 +34,14 @@ def create_user_profile(sender, **kwargs):
 def profile_following_change(sender, instance, action, **kwargs):
     """Deliver notification on new followers."""
     if action in ["post_add", "post_remove"]:
+        logger.debug("profile_following_change - Got %s from %s for %s - waiting for commit", action, sender, instance)
         def on_commit():
+            logger.debug("profile_following_change - Commit happened!")
+            logger.debug("profile_following_change - pk_set %s", kwargs.get("pk_set"))
             for id in kwargs.get("pk_set"):
                 if action == "post_add":
+                    logger.debug("profile_following_change - Enqueue follow notification with %s and %s",
+                                 instance.id, id)
                     django_rq.enqueue(send_follow_notification, instance.id, id)
                 # Send out on the federation layer if local follower, remote followed/unfollowed
                 if Profile.objects.filter(id=id, user__isnull=True).exists() and instance.user:

--- a/socialhome/users/tests/test_signals.py
+++ b/socialhome/users/tests/test_signals.py
@@ -4,7 +4,6 @@ import pytest
 from django.test import TransactionTestCase
 
 from socialhome.federate.tasks import send_follow_change
-from socialhome.notifications.tasks import send_follow_notification
 from socialhome.users.tests.factories import UserFactory, ProfileFactory
 
 
@@ -32,17 +31,11 @@ class TestProfileFollowingChange(TransactionTestCase):
         self.profile = ProfileFactory()
 
     @patch("socialhome.users.signals.django_rq.enqueue")
-    def test_adding_follower_sends_a_notification(self, mock_enqueue):
-        self.profile2.following.add(self.user.profile)
-        mock_enqueue.assert_called_once_with(send_follow_notification, self.profile2.id, self.user.profile.id)
-
-    @patch("socialhome.users.signals.django_rq.enqueue")
     def test_adding_remote_follower_triggers_federation_event(self, mock_enqueue):
         self.profile2.following.add(self.profile)
         self.assertEqual(
             mock_enqueue.call_args_list,
             [
-                call(send_follow_notification, self.profile2.id, self.profile.id),
                 call(send_follow_change, self.profile2.id, self.profile.id, True),
             ]
         )

--- a/socialhome/users/viewsets.py
+++ b/socialhome/users/viewsets.py
@@ -28,9 +28,9 @@ class ProfileViewSet(ModelViewSet):
     def add_follower(self, request, pk=None):
         guid = request.data.get("guid")
         try:
-            target_profile = Profile.objects.visible_for_user(request.user).get(guid=guid)
+            target_profile = Profile.objects.get(guid=guid)
         except Profile.DoesNotExist:
-            raise PermissionDenied("Profile given either does not exist or is not visible.")
+            raise PermissionDenied("Profile given does not exist.")
         profile = self.get_object()
         if profile.guid == guid:
             raise ValidationError("Cannot follow self!")


### PR DESCRIPTION
In stream and content detail view, allow following/unfollowing users.

Also, send out remote unfollows.

TODO:
* [x] Fix and improve tests
* [x] Consider adding follow/unfollow to modal too - or consider removing modal.. ---> remove modal sounds nicer, logged #162 
* [x] Check why follow notification wasn't delivered from some contacts but for some they were? Maybe a timing issue with RQ processing jobs that are not in the db, again?
* [x] Fix federating following between Socialhome instances
* [x] Make follow/unfollow button nicer
* [x] No reply author information (and thus no follow/unfollow) in single content view)

Closes #143 