### PR TITLE
Support stream connection groups with quoted urls

### DIFF
--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -9,6 +9,7 @@ from socialhome.content.forms import ContentForm
 from socialhome.content.models import Content
 from socialhome.content.tests.factories import ContentFactory, LocalContentFactory
 from socialhome.content.views import ContentCreateView, ContentUpdateView, ContentDeleteView
+from socialhome.tests.utils import SocialhomeTestCase
 from socialhome.users.models import Profile
 from socialhome.users.tests.factories import UserFactory
 
@@ -179,9 +180,7 @@ class TestContentDeleteView:
         assert response.status_code == 404
 
 
-class TestContentView(TestCase):
-    maxDiff = None
-
+class TestContentView(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -267,6 +266,13 @@ class TestContentView(TestCase):
             reverse("content:view", kwargs={"pk": self.content.id})
         )
         self.assertNotContains(response, '<span id="content-bar-actions" class="hidden"')
+
+    def test_content_view_guid_quoting(self):
+        content = ContentFactory(guid="foo@bar", visibility=Visibility.PUBLIC)
+        response = self.client.get(
+            reverse("content:view", kwargs={"pk": content.id})
+        )
+        self.assertEqual(response.context["stream_name"], "foo%40bar")
 
 
 class TestContentReplyView(TestCase):

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from braces.views import UserPassesTestMixin, JSONResponseMixin, AjaxResponseMixin, LoginRequiredMixin
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -106,6 +108,11 @@ class ContentView(ContentVisibleForUserMixin, AjaxResponseMixin, JSONResponseMix
     def get_ajax(self, request, *args, **kwargs):
         self.object = self.get_object()
         return self.render_json_response(self.object.dict_for_view(request.user))
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["stream_name"] = quote_plus(self.object.guid)
+        return context
 
 
 class HomeView(TemplateView):

--- a/socialhome/streams/consumers.py
+++ b/socialhome/streams/consumers.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import unquote_plus
 
 from channels.generic.websockets import WebsocketConsumer
 
@@ -10,7 +11,7 @@ class StreamConsumer(WebsocketConsumer):
     channel_session_user = True
 
     def connection_groups(self, **kwargs):
-        return ["streams_%s" % kwargs.get("stream")]
+        return ["streams_%s" % unquote_plus(kwargs.get("stream"))]
 
     def receive(self, text=None, bytes=None, **kwargs):
         data = json.loads(text)

--- a/socialhome/streams/tests/test_consumers.py
+++ b/socialhome/streams/tests/test_consumers.py
@@ -108,3 +108,4 @@ class TestStreamConsumerConnectionGroups(SimpleTestCase):
     def test_connection_groups(self, mock_consumer):
         consumer = StreamConsumer()
         self.assertEqual(consumer.connection_groups(stream="foobar"), ["streams_foobar"])
+        self.assertEqual(consumer.connection_groups(stream="foo%40bar"), ["streams_foo@bar"])


### PR DESCRIPTION
Some content guid's (looking at you hubzilla) have @ in them. Quote and then unquote the stream name to ensure it survives passing in as stream name.

Closes #161