### PR TITLE
Fix single content view reply loading issue due to long guids

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,8 @@ wheel==0.29.0
 django==1.10.7
 
 # Channels
-channels==1.1.3
-asgi_redis==1.2.1
+channels==1.1.6
+asgi_redis==1.4.2
 
 # Configuration
 django-environ==0.4.3

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -187,6 +187,15 @@ class Content(models.Model):
     def slug(self):
         return slugify(self.short_text)
 
+    @property
+    def channel_group_name(self):
+        """Make a safe Channel group name.
+
+        ASCII or hyphens or periods only.
+        Prefix with ID as we have to cut long guids due to asgi library group name restriction.
+        """
+        return ("%s%s" % (self.id, slugify(self.guid)))[:80]
+
     def render(self):
         """Pre-render text to Content.rendered."""
         text = self.get_and_linkify_tags()

--- a/socialhome/content/signals.py
+++ b/socialhome/content/signals.py
@@ -59,7 +59,7 @@ def notify_listeners(content):
     data = json.dumps({"event": "new", "id": content.id})
     if content.parent:
         # Content comments
-        StreamConsumer.group_send("streams_content__%s" % content.parent.guid, data)
+        StreamConsumer.group_send("streams_content__%s" % content.parent.channel_group_name, data)
     else:
         # Public stream
         if content.visibility == Visibility.PUBLIC:

--- a/socialhome/content/templates/content/detail.html
+++ b/socialhome/content/templates/content/detail.html
@@ -14,6 +14,6 @@
 {% endblock %}
 
 {% block content %}
-    <script>var socialhomeStream = "content__{{ content.guid }}";</script>
+    <script>var socialhomeStream = "{{ stream_name }}";</script>
     {% include "content/_content_detail.html" with modal=False content=content %}
 {% endblock %}

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -327,6 +327,17 @@ class TestContentModel(TestCase):
         self.assertTrue(self.self_content.visible_for_user(Mock(is_authenticated=True, profile=profile)))
         self.assertFalse(self.limited_content.visible_for_user(Mock(is_authenticated=True, profile=profile)))
 
+    def test_channel_group_name(self):
+        self.assertEquals(
+            self.public_content.channel_group_name, "%s%s" % (self.public_content.id, slugify(self.public_content.guid))
+        )
+        long_non_ascii_guid_content = ContentFactory(guid="ä"*150)
+        self.assertEquals(
+            long_non_ascii_guid_content.channel_group_name, "%s%s" % (
+                long_non_ascii_guid_content.id, "a"*(80-len(str(long_non_ascii_guid_content.id)))
+            )
+        )
+
 
 @pytest.mark.usefixtures("db")
 class TestContentSaveTags(TestCase):

--- a/socialhome/content/tests/test_signals.py
+++ b/socialhome/content/tests/test_signals.py
@@ -58,7 +58,7 @@ class TestNotifyListeners(SocialhomeTestCase):
         # Replies
         reply = ContentFactory(parent=content)
         data = json.dumps({"event": "new", "id": reply.id})
-        mock_consumer.group_send.assert_called_once_with("streams_content__%s" % content.guid, data)
+        mock_consumer.group_send.assert_called_once_with("streams_content__%s" % content.channel_group_name, data)
         mock_consumer.group_send.reset_mock()
         # Update shouldn't cause a group send
         content.text = "foo"

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -233,7 +233,7 @@ class TestContentView(SocialhomeTestCase):
         self.assertContains(response, self.content.formatted_timestamp)
         self.assertContains(response, '<span id="content-bar-actions" class="hidden"')
         self.assertNotContains(response, "modal-footer")
-        self.assertContains(response, 'var socialhomeStream = "content__%s' % self.content.guid)
+        self.assertContains(response, 'var socialhomeStream = "content__%s' % self.content.channel_group_name)
 
     def test_content_view_content_as_author(self):
         self.client.force_login(self.content.author.user)
@@ -241,13 +241,6 @@ class TestContentView(SocialhomeTestCase):
             reverse("content:view", kwargs={"pk": self.content.id})
         )
         self.assertNotContains(response, '<span id="content-bar-actions" class="hidden"')
-
-    def test_content_view_guid_quoting(self):
-        content = ContentFactory(guid="foo@bar", visibility=Visibility.PUBLIC)
-        response = self.client.get(
-            reverse("content:view", kwargs={"pk": content.id})
-        )
-        self.assertEqual(response.context["stream_name"], "foo%40bar")
 
 
 class TestContentReplyView(TestCase):

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -1,5 +1,3 @@
-from urllib.parse import quote_plus
-
 from braces.views import UserPassesTestMixin, JSONResponseMixin, AjaxResponseMixin, LoginRequiredMixin
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
@@ -108,5 +106,5 @@ class ContentView(ContentVisibleForUserMixin, AjaxResponseMixin, JSONResponseMix
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["stream_name"] = quote_plus(self.object.guid)
+        context["stream_name"] = "content__%s" % self.object.channel_group_name
         return context

--- a/socialhome/streams/consumers.py
+++ b/socialhome/streams/consumers.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import unquote_plus
 
 from channels.generic.websockets import WebsocketConsumer
 
@@ -11,7 +10,7 @@ class StreamConsumer(WebsocketConsumer):
     channel_session_user = True
 
     def connection_groups(self, **kwargs):
-        return ["streams_%s" % unquote_plus(kwargs.get("stream"))]
+        return ["streams_%s" % kwargs.get("stream")]
 
     def receive(self, text=None, bytes=None, **kwargs):
         data = json.loads(text)

--- a/socialhome/streams/tests/test_consumers.py
+++ b/socialhome/streams/tests/test_consumers.py
@@ -127,4 +127,3 @@ class TestStreamConsumerConnectionGroups(SimpleTestCase):
     def test_connection_groups(self, mock_consumer):
         consumer = StreamConsumer()
         self.assertEqual(consumer.connection_groups(stream="foobar"), ["streams_foobar"])
-        self.assertEqual(consumer.connection_groups(stream="foo%40bar"), ["streams_foo@bar"])


### PR DESCRIPTION
Earlier fix was made to fix issue with guids that have @ in them. The fix
wasn't really done properly and fixing it properly exposed another problem.
'asgiref' library limits Channels group name length to 99 chars.

Do a Content.id + Content.guid to get some extra uniqueness to the group
name, then slugify it and cut it at 80 chars (since we prefix it with
'streams_content__'. This should offer enough uniqueness to provide WS
notifications to the frontend. Even if a clash happens, only an ID is ever
delivered to the frontend, not a whole content.