### PR TITLE
Correctly send replies to remotes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,10 @@ Fixed
 .....
 
 * Make reply notifications to local users not send one single email with all local participants, but one email per participant. Previous implementation would have leaked emails of participants to other participants.
+* Correctly send replies to remotes (`#210 <https://github.com/jaywink/socialhome/issues/210>`_)
+
+  If parent content is local, send via the relayable forwarding mechanism. This ensures parent author signs the content. If parent author is remote, send just to the remote author. The remote author should then relay it.
+
 
 0.1.0 (2017-07-27)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,7 +24,7 @@ Fixed
 * Correctly send replies to remotes (`#210 <https://github.com/jaywink/socialhome/issues/210>`_)
 
   If parent content is local, send via the relayable forwarding mechanism. This ensures parent author signs the content. If parent author is remote, send just to the remote author. The remote author should then relay it.
-
+* Ensure calling ``Profile.private_key`` or ``Profile.key`` don't crash if the profile doesn't have keys. Now the properties just return ``None``.
 
 0.1.0 (2017-07-27)
 ------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ django-extensions==1.7.9
 # Federation
 #federation==0.12.0
 # for quick overriding a commit version
-git+https://github.com/jaywink/federation.git@10fa2cf846cbf4a15ffc565e5184e5cdebd891dd#egg=federation==0.12.0.1
+git+https://github.com/jaywink/federation.git@55afde60cd3d7a01a8b93c8080ef17b2e1f40aa0#egg=federation==0.13.0.1
 
 # Content
 django-markdownx==2.0.21

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ django-extensions==1.7.9
 # Federation
 #federation==0.12.0
 # for quick overriding a commit version
-git+https://github.com/jaywink/federation.git@55afde60cd3d7a01a8b93c8080ef17b2e1f40aa0#egg=federation==0.13.0.1
+git+https://github.com/jaywink/federation.git@977c584d9669ef7363f3dcdcb3b42167b0ea0ff5#egg=federation==0.13.0.1
 
 # Content
 django-markdownx==2.0.21

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -139,7 +139,8 @@ class Profile(TimeStampedModel):
 
         Corresponds to private key.
         """
-        return RSA.importKey(self.rsa_private_key)
+        if self.rsa_private_key:
+            return RSA.importKey(self.rsa_private_key)
 
     @cached_property
     def key(self):
@@ -147,7 +148,8 @@ class Profile(TimeStampedModel):
 
         Corresponds to public key.
         """
-        return RSA.importKey(self.rsa_public_key)
+        if self.rsa_public_key:
+            return RSA.importKey(self.rsa_public_key)
 
     @property
     def public(self):


### PR DESCRIPTION
If parent content is local, send via the relayable forwarding mechanism. This ensures parent author signs the content. If parent author is remote, send just to the remote author. The remote author should then relay it.

Closes #210