### PR TITLE
Fix reply notifications to local users participants list

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,11 @@ Added
 
 * When searching for profiles based on handle, fetch profile from remote if it isn't found locally (`#163 <https://github.com/jaywink/socialhome/issues/163>`_)
 
+Fixed
+.....
+
+* Make reply notifications to local users not send one single email with all local participants, but one email per participant. Previous implementation would have leaked emails of participants to other participants.
+
 0.1.0 (2017-07-27)
 ------------------
 

--- a/socialhome/notifications/tasks.py
+++ b/socialhome/notifications/tasks.py
@@ -36,13 +36,14 @@ def send_reply_notifications(content_id):
         settings.SOCIALHOME_URL,
         reverse("content:view-by-slug", kwargs={"pk": parent.id, "slug": parent.slug}),
     )
-    send_mail(
-        "%sNew reply to content you have participated in" % settings.EMAIL_SUBJECT_PREFIX,
-        "There is a new reply to content you have participated in, see it here: %s" % parent_url,
-        settings.DEFAULT_FROM_EMAIL,
-        participants,
-        fail_silently=False,
-    )
+    for participant in participants:
+        send_mail(
+            "%sNew reply to content you have participated in" % settings.EMAIL_SUBJECT_PREFIX,
+            "There is a new reply to content you have participated in, see it here: %s" % parent_url,
+            settings.DEFAULT_FROM_EMAIL,
+            [participant],
+            fail_silently=False,
+        )
 
 
 def send_follow_notification(follower_id, followed_id):


### PR DESCRIPTION
Make reply notifications to local users not send one single email with all local participants, but one email per participant. Previous implementation would have leaked emails of participants to other participants.