### PR TITLE
Filter out "limited" visibility profiles from API list results

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Fixed
   If parent content is local, send via the relayable forwarding mechanism. This ensures parent author signs the content. If parent author is remote, send just to the remote author. The remote author should then relay it.
 * Ensure calling ``Profile.private_key`` or ``Profile.key`` don't crash if the profile doesn't have keys. Now the properties just return ``None``.
 * Fix regression in profile all content stream load more functionality. (`#190 <https://github.com/jaywink/socialhome/issues/190>`_)
+* Filter out "limited" visibility profiles from API list results. These profiles are not available in the search so they shouldn't be available to list through the API either.
 
 0.1.0 (2017-07-27)
 ------------------

--- a/socialhome/users/tests/test_viewsets.py
+++ b/socialhome/users/tests/test_viewsets.py
@@ -58,10 +58,10 @@ class TestProfileViewSet(APITestCase):
         cls.profile = cls.user.profile
         cls.staff_user = UserFactory(is_staff=True)
         cls.staff_profile = cls.staff_user.profile
-        cls.site_profile = ProfileFactory()
-        cls.self_profile = ProfileFactory()
+        cls.site_profile = ProfileFactory(visibility=Visibility.SITE)
+        cls.self_profile = ProfileFactory(visibility=Visibility.SELF)
+        cls.limited_profile = ProfileFactory(visibility=Visibility.LIMITED)
         Profile.objects.filter(id=cls.profile.id).update(visibility=Visibility.PUBLIC)
-        Profile.objects.filter(id=cls.site_profile.id).update(visibility=Visibility.SITE)
 
     def test_profile_list(self):
         url = reverse("api:profile-list")
@@ -81,7 +81,7 @@ class TestProfileViewSet(APITestCase):
         self.client.login(username=self.staff_user.username, password="password")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data.get("results")), 4)
+        self.assertEqual(len(response.data.get("results")), 5)
 
     def test_profile_get(self):
         # Not authenticated


### PR DESCRIPTION
These profiles are not available in the search so they shouldn't be available to list through the API either.