### PR TITLE
Fix XSS vulnerability in profile edit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,13 @@ Changelog
 [unreleased]
 ------------
 
+Security
+........
+
+* Fix XSS vulnerability in profile edit. Unsanitized profile field input was allowed and one place showed a field without escaping it. The fields are now sanitized and escaping has been ensured.
+
+  The problem concerned only local users and not remote profile fields which were correctly sanitized already.
+
 Added
 .....
 

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -11,6 +11,7 @@ from django.template.loader import render_to_string
 from django.urls import NoReverseMatch
 from django.urls import reverse
 from django.utils.functional import cached_property
+from django.utils.html import escape
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.utils.text import truncate_letters
@@ -303,7 +304,7 @@ class Content(models.Model):
             "rendered": self.rendered,
             "author": self.author_id,
             "author_guid": self.author.guid,
-            "author_name": self.author.name or self.author.handle,
+            "author_name": escape(self.author.name) or self.author.handle,
             "author_handle": self.author.handle,
             "author_image": self.author.safer_image_url_small,
             "author_profile_url": self.author.get_absolute_url(),

--- a/socialhome/users/forms.py
+++ b/socialhome/users/forms.py
@@ -1,0 +1,13 @@
+from django.forms import ModelForm
+
+from socialhome.content.utils import safe_text
+from socialhome.users.models import Profile
+
+
+class ProfileForm(ModelForm):
+    class Meta:
+        model = Profile
+        fields = ["name", "visibility"]
+
+    def clean_name(self):
+        return safe_text(self.cleaned_data["name"])

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -6,6 +6,7 @@ from django.views.generic import DetailView, ListView, UpdateView
 from django.contrib.auth.mixins import LoginRequiredMixin, AccessMixin
 
 from socialhome.content.models import Content
+from socialhome.users.forms import ProfileForm
 from socialhome.users.models import User, Profile
 from socialhome.users.tables import FollowedTable
 
@@ -123,7 +124,7 @@ class OrganizeContentProfileDetailView(ProfileDetailView):
 
 
 class ProfileUpdateView(LoginRequiredMixin, UpdateView):
-    fields = ["name", "visibility"]
+    form_class = ProfileForm
     model = Profile
 
     def get_success_url(self):


### PR DESCRIPTION
Unsanitized profile field input was allowed and one place showed a field without escaping it. The fields are now sanitized and escaping has been ensured.

The problem concerned only local users and not remote profile fields which were correctly sanitized already.