### PR TITLE
Add API docs

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -43,6 +43,7 @@ THIRD_PARTY_APPS = (
     "django_rq",
     "rest_framework",
     "rest_framework.authtoken",
+    "rest_framework_swagger",
     "dynamic_preferences",
     "dynamic_preferences.users.apps.UserPreferencesConfig",
     "django_tables2",
@@ -232,6 +233,7 @@ SOCIALACCOUNT_ADAPTER = "socialhome.users.adapters.SocialAccountAdapter"
 AUTH_USER_MODEL = "users.User"
 LOGIN_REDIRECT_URL = "home"
 LOGIN_URL = "account_login"
+LOGOUT_URL = "account_logout"
 
 # SLUGLIFIER
 AUTOSLUG_SLUGIFY_FUNCTION = "slugify.slugify"
@@ -402,6 +404,13 @@ REST_FRAMEWORK = {
         "content_create": "100/day",
     },
     "DEFAULT_VERSION": "0.1",
+}
+
+# REST SWAGGER
+# ------------
+SWAGGER_SETTINGS = {
+    "APIS_SORTER": "alpha",
+    "DOC_EXPANSION": "list",
 }
 
 # DYNAMIC PREFERENCES

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,6 +7,8 @@ from django.views import defaults as default_views
 from django.views.i18n import javascript_catalog
 from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
+from rest_framework.schemas import get_schema_view
+from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
 
 from socialhome.content.viewsets import ContentViewSet
 from socialhome.viewsets import ImageUploadView
@@ -22,6 +24,9 @@ router = DefaultRouter()
 router.register(r"content", ContentViewSet)
 router.register(r"profiles", ProfileViewSet)
 router.register(r"users", UserViewSet)
+
+# API docs
+schema_view = get_schema_view(title="Socialhome API", renderer_classes=[OpenAPIRenderer, SwaggerUIRenderer])
 
 urlpatterns = [
     url(r"", include("socialhome.federate.urls", namespace="federate")),
@@ -52,6 +57,7 @@ urlpatterns = [
     url(r"^django-rq/", include("django_rq.urls")),
 
     # API
+    url(r"^api/$", schema_view, name="api-docs"),
     url(r"^api/", include(router.urls, namespace="api")),
     url(r"^api/image-upload/$", ImageUploadView.as_view(), name="api-image-upload"),
     url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Added
 
     * Content API allows browsing content objects that are visible to self, or public for anonymous users. Content objects owned by self can be updated or deleted. Creating content is also possible.
     * Image Upload API allows uploading images via the same mechanism that is used in the content create UI form. The uploaded image will be stored and a markdown string is passed back which can be added to content created in for example mobile clients. Note, uploading an image doesn't create any content itself, it just allows embedding images into content, just like in the UI.
+* New API docs exposed by Django REST Swagger. These are in the same place as the old ones, at ``/api/``. Adding to the documentation is still a work in progress.
 
 0.2.1 (2017-07-30)
 ------------------

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -73,6 +73,7 @@ ipython
 
 # API
 djangorestframework==3.6.3
+django-rest-swagger==2.1.2
 
 # User settings
 django-dynamic-preferences==1.2

--- a/socialhome/templates/rest_framework_swagger/index.html
+++ b/socialhome/templates/rest_framework_swagger/index.html
@@ -1,0 +1,7 @@
+{% extends "rest_framework_swagger/base.html" %}
+
+{% block logo %}
+    <div class="input" style="float: left; margin-top: 5px;">
+        <a class="header__btn" href="/">{{ request.site.name }}</a>
+    </div>
+{% endblock %}

--- a/socialhome/viewsets.py
+++ b/socialhome/viewsets.py
@@ -11,6 +11,14 @@ class ImageUploadThrottle(UserRateThrottle):
 
 
 class ImageUploadView(CreateAPIView):
+    """
+    post:
+        Upload an image
+
+        Return is JSON containing the ``url`` to the uploaded image and the markdown ``code`` to
+        embed the image in content. NOTE! Uploading an image doesn't post it out or create automatic content.
+        Uploaded images must be followed by a "content" create with the uploaded images added to the content text.
+    """
     serializer_class = ImageUploadSerializer
     permission_classes = (IsAuthenticated,)
     parser_classes = (MultiPartParser, FormParser)


### PR DESCRIPTION
Replace the built in browsable API with Django REST Swagger generated docs. These live in the API root /api/ as the previous browseable API endpoint.