### PR TITLE
Tweak Profile viewset permissions

### DIFF
--- a/socialhome/users/tests/test_viewsets.py
+++ b/socialhome/users/tests/test_viewsets.py
@@ -115,11 +115,11 @@ class TestProfileViewSet(APITestCase):
         response = self.client.patch(
             reverse("api:profile-detail", kwargs={"pk": self.site_profile.id}), {"name": "foo"}
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         response = self.client.patch(
             reverse("api:profile-detail", kwargs={"pk": self.self_profile.id}), {"name": "foo"}
         )
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 403)
         # Normal user authenticated
         self.client.login(username=self.user.username, password="password")
         response = self.client.patch(reverse("api:profile-detail", kwargs={"pk": self.profile.id}), {"name": "foo"})

--- a/socialhome/users/viewsets.py
+++ b/socialhome/users/viewsets.py
@@ -11,6 +11,15 @@ from socialhome.users.serializers import UserSerializer, ProfileSerializer
 
 
 class IsOwnProfileOrReadOnly(BasePermission):
+    def has_permission(self, request, view):
+        if request.method in SAFE_METHODS:
+            return True
+
+        if not request.user.is_authenticated:
+            return False
+
+        return True
+
     def has_object_permission(self, request, view, obj):
         if request.method in SAFE_METHODS:
             return True


### PR DESCRIPTION
While technically it wasn't possible to edit a profile not being logged in, the API routes were visible in the docs. Properly implement 'has_permission' in the viewset permission class to tell the API anonymous users can't use put/patch into profile.