### PR TITLE
Tweak various Content success url behaviours

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Changed
 .......
 
 * Create and update content will now redirect to the content created or updated. Previous behaviour was user preferred landing page.
+* Delete content will now redirect back to the page where the delete was triggered from. Previous behaviour was user preferred landing page. If the content delete is triggered from the content detail page, redirect will happen to user preferred landing page as before. (`#204 <https://github.com/jaywink/socialhome/issues/204>`_)
 
 Fixed
 .....

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,8 +13,19 @@ Added
 
     * Content API allows browsing content objects that are visible to self, or public for anonymous users. Content objects owned by self can be updated or deleted. Creating content is also possible.
     * Image Upload API allows uploading images via the same mechanism that is used in the content create UI form. The uploaded image will be stored and a markdown string is passed back which can be added to content created in for example mobile clients. Note, uploading an image doesn't create any content itself, it just allows embedding images into content, just like in the UI.
+
 * New API docs exposed by Django REST Swagger. These are in the same place as the old ones, at ``/api/``. Adding to the documentation is still a work in progress.
 * Add image upload button to the create/reply editor. This makes it possible to upload images from mobile browsers. (`#120 <https://github.com/jaywink/socialhome/issues/120>`_)
+
+Changed
+.......
+
+* Create and update content will now redirect to the content created or updated. Previous behaviour was user preferred landing page.
+
+Fixed
+.....
+
+* Fix internal server error when replying to content that contained only characters outside the western Latin character sets.
 
 0.2.1 (2017-07-30)
 ------------------

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -117,6 +117,11 @@ class Content(models.Model):
             text=truncate_letters(self.text, 100), guid=self.guid
         )
 
+    def get_absolute_url(self):
+        if self.slug:
+            return reverse("content:view-by-slug", kwargs={"pk": self.id, "slug": self.slug})
+        return reverse("content:view", kwargs={"pk": self.id})
+
     def save(self, *args, **kwargs):
         if self.parent:
             # Ensure replies have sane values

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -65,7 +65,7 @@ class Tag(models.Model):
         self.name = self.name.strip().lower()
         super().save()
 
-    @property
+    @cached_property
     def channel_group_name(self):
         """Make a safe Channel group name.
 
@@ -162,7 +162,7 @@ class Content(models.Model):
     def is_nsfw(self):
         return self.text.lower().find("#nsfw") > -1
 
-    @property
+    @cached_property
     def is_local(self):
         if self.author.user:
             return True
@@ -195,15 +195,15 @@ class Content(models.Model):
     def formatted_timestamp(self):
         return arrow.get(self.modified).format()
 
-    @property
+    @cached_property
     def short_text(self):
         return truncate_letters(self.text, 50)
 
-    @property
+    @cached_property
     def slug(self):
         return slugify(self.short_text)
 
-    @property
+    @cached_property
     def channel_group_name(self):
         """Make a safe Channel group name.
 

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -46,6 +46,14 @@ class TestContentModel(SocialhomeTestCase):
     def setUp(self):
         super().setUp()
         self.public_content.refresh_from_db()
+        try:
+            del self.public_content.short_text
+        except AttributeError:
+            pass
+        try:
+            del self.public_content.slug
+        except AttributeError:
+            pass
         self.site_content.refresh_from_db()
 
     def test_create(self):
@@ -124,6 +132,7 @@ class TestContentModel(SocialhomeTestCase):
         self.assertFalse(self.site_content.is_local)
         self.site_content.author = self.profile
         self.site_content.save()
+        del self.site_content.is_local
         self.assertTrue(self.site_content.is_local)
 
     def test_save_calls_fix_local_uploads(self):

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -299,6 +299,15 @@ class TestContentModel(SocialhomeTestCase):
         self.assertEqual(reply.visibility, Visibility.PUBLIC)
         self.assertFalse(reply.pinned)
 
+    def test_get_absolute_url(self):
+        self.assertEqual(self.public_content.get_absolute_url(),
+                         "/content/%s/%s/" % (self.public_content.id, self.public_content.slug))
+        self.public_content.text = "बियर राम्रो छ"
+        self.public_content.save()
+        del self.public_content.slug
+        del self.public_content.short_text
+        self.assertEqual(self.public_content.get_absolute_url(), "/content/%s/" % self.public_content.id)
+
 
 class TestContentRendered(SocialhomeTestCase):
     def test_renders(self):

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -32,10 +32,6 @@ class TestContentCreateView:
         assert content.author == request.user.profile
         assert content.visibility == Visibility.PUBLIC
 
-    def test_get_success_url(self, admin_client, rf):
-        request, view = self._get_request_and_view(rf)
-        assert view.get_success_url() == "/"
-
     def test_create_view_renders(self, admin_client, rf):
         response = admin_client.get(reverse("content:create"))
         assert response.status_code == 200
@@ -74,10 +70,6 @@ class TestContentUpdateView:
         assert content.author == request.user.profile
         assert content.visibility == Visibility.PUBLIC
         assert content.text == "barfoo"
-
-    def test_get_success_url(self, admin_client, rf):
-        request, view, content = self._get_request_view_and_content(rf)
-        assert view.get_success_url() == "/"
 
     def test_update_view_renders(self, admin_client, rf):
         profile = Profile.objects.get(user__username="admin")

--- a/socialhome/content/tests/test_views.py
+++ b/socialhome/content/tests/test_views.py
@@ -113,8 +113,11 @@ class TestContentUpdateView:
 
 @pytest.mark.usefixtures("admin_client", "rf")
 class TestContentDeleteView:
-    def _get_request_view_and_content(self, rf):
-        request = rf.get("/")
+    def _get_request_view_and_content(self, rf, next=False):
+        if next:
+            request = rf.get("/?next=/foobar")
+        else:
+            request = rf.get("/")
         request.user = UserFactory()
         content = ContentFactory(author=request.user.profile)
         view = ContentDeleteView(request=request, kwargs={"pk": content.id})
@@ -124,6 +127,8 @@ class TestContentDeleteView:
     def test_get_success_url(self, admin_client, rf):
         request, view, content = self._get_request_view_and_content(rf)
         assert view.get_success_url() == "/"
+        request, view, content = self._get_request_view_and_content(rf, next=True)
+        assert view.get_success_url() == "/foobar"
 
     def test_delete_view_renders(self, admin_client, rf):
         profile = Profile.objects.get(user__username="admin")

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -39,16 +39,13 @@ class ContentCreateView(LoginRequiredMixin, CreateView):
         object = form.save(commit=False)
         object.author = self.request.user.profile
         object.save()
-        return HttpResponseRedirect(self.get_success_url())
+        return HttpResponseRedirect(object.get_absolute_url())
 
     def get_form_kwargs(self):
         """Add user to form kwargs."""
         kwargs = super(ContentCreateView, self).get_form_kwargs()
         kwargs.update({"user": self.request.user, "is_reply": self.is_reply})
         return kwargs
-
-    def get_success_url(self):
-        return reverse("home")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -72,7 +69,7 @@ class ContentReplyView(ContentVisibleForUserMixin, ContentCreateView):
         return HttpResponseRedirect(self.get_success_url())
 
     def get_success_url(self):
-        return reverse("content:view-by-slug", kwargs={"pk": self.parent.id, "slug": self.parent.slug})
+        return self.parent.get_absolute_url()
 
 
 class ContentUpdateView(UserOwnsContentMixin, UpdateView):
@@ -90,7 +87,7 @@ class ContentUpdateView(UserOwnsContentMixin, UpdateView):
         return kwargs
 
     def get_success_url(self):
-        return reverse("home")
+        return self.object.get_absolute_url()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -104,6 +104,9 @@ class ContentDeleteView(UserOwnsContentMixin, DeleteView):
     template_name = "content/delete.html"
 
     def get_success_url(self):
+        next = self.request.GET.get("next")
+        if next:
+            return next
         return reverse("home")
 
 

--- a/socialhome/static/js/content.js
+++ b/socialhome/static/js/content.js
@@ -35,7 +35,7 @@
                             '<span id="content-bar-actions"> ' +
                                 '&nbsp;' +
                                 '<a id="content-update-link" href="<%= content.update_url %>"><i class="fa fa-pencil" title="' + gettext("Update") + '" aria-label="' + gettext("Update") + '"></i></a> ' +
-                                '<a id="content-delete-link" href="<%= content.delete_url %>"><i class="fa fa-remove" title="' + gettext("Delete") + '" aria-label="' + gettext("Delete") + '"></i></a>' +
+                                '<a id="content-delete-link" href="<%= content.delete_url %>?next='+ window.location.pathname +'"><i class="fa fa-remove" title="' + gettext("Delete") + '" aria-label="' + gettext("Delete") + '"></i></a>' +
                             '</span>' +
                         '<% } %>' +
                     '</div>' +

--- a/socialhome/streams/templates/streams/base.html
+++ b/socialhome/streams/templates/streams/base.html
@@ -59,7 +59,7 @@
                                 {% if content.author == request.user.profile %}
                                     &nbsp;
                                     <a href="{% url "content:update" content.id %}"><i class="fa fa-pencil" title="{% trans "Update" %}" aria-label="{% trans "Update" %}"></i></a>
-                                    <a href="{% url "content:delete" content.id %}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
+                                    <a href="{% url "content:delete" content.id %}?next={{ request.path }}"><i class="fa fa-remove" title="{% trans "Delete" %}" aria-label="{% trans "Delete" %}"></i></a>
                                 {% endif %}
                             </div>
                             <div class="col-3 text-right grid-item-reactions mt-1">


### PR DESCRIPTION
* Redirect logically after content delete
* Fix internal server error when replying to content that contained only characters outside the western Latin character sets
* Make content create and update redirect logically to the content in question.

Closes #204