### PR TITLE
Security updates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,15 @@ Changelog
 [unreleased]
 ------------
 
+Security
+........
+
+* Reject remote content updates via the federation layer which reference an already existing remote content object but have a different author.
+
+  Note that locally created content was previously safe from this kind of takeover. This, even though serious, affects only remote created content stored locally.
+
+* Reject remote reply updates via the federation layer which try to change the parent content reference.
+
 Added
 .....
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,8 @@ Security
 
 * Reject remote reply updates via the federation layer which try to change the parent content reference.
 
+* Bump `federation <https://github.com/jaywink/federation/releases/tag/v0.14.0>`_ to ensure remote entity authorship is verified correctly.
+
 Added
 .....
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,9 +52,9 @@ django-rq==0.9.5
 django-extensions==1.7.9
 
 # Federation
-#federation==0.12.0
+federation==0.14.0
 # for quick overriding a commit version
-git+https://github.com/jaywink/federation.git@977c584d9669ef7363f3dcdcb3b42167b0ea0ff5#egg=federation==0.13.0.1
+#git+https://github.com/jaywink/federation.git@977c584d9669ef7363f3dcdcb3b42167b0ea0ff5#egg=federation==0.13.0.1
 
 # Content
 django-markdownx==2.0.21


### PR DESCRIPTION
* Bump `federation <https://github.com/jaywink/federation/releases/tag/v0.14.0>`_ to ensure remote entity authorship is verified correctly.
* Reject remote content updates via the federation layer which reference an already existing remote content object but have a different author.
* Reject remote reply updates via the federation layer which try to change the parent content reference.