### PR TITLE
Process remote profiles entities on receive

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Added
   Profile menu now has an extra option "Change picture". This allows uploading a new picture and optionally setting focus point for cropping a picture that is not square shape.
 
 * Federate local profiles to remote followers on save. (`#168 <https://github.com/jaywink/socialhome/issues/168>`_)
+* Process remote profiles entities on receive.
+
+  Remote profiles were so far only created on first encounter. Now we also process incoming ``Profile`` entities from the federation layer.
 
 0.3.1 (2017-08-06)
 ------------------

--- a/socialhome/federate/utils/tasks.py
+++ b/socialhome/federate/utils/tasks.py
@@ -48,6 +48,8 @@ def process_entities(entities):
                 process_entity_relationship(entity, profile)
             elif isinstance(entity, base.Follow):
                 process_entity_follow(entity, profile)
+            elif isinstance(entity, base.Profile):
+                Profile.from_remote_profile(entity)
         except Exception as ex:
             logger.exception("Failed to handle %s: %s", entity.guid, ex)
 

--- a/socialhome/users/tests/factories.py
+++ b/socialhome/users/tests/factories.py
@@ -1,6 +1,8 @@
 import factory
 from factory import fuzzy
 
+from federation.entities import base
+
 
 class UserFactory(factory.django.DjangoModelFactory):
     username = factory.Sequence(lambda n: "user-{0}".format(n))
@@ -35,3 +37,24 @@ class ProfileFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = "users.Profile"
+
+
+class BaseProfileFactory(factory.Factory):
+    class Meta:
+        model = base.Profile
+
+    handle = factory.Faker("safe_email")
+    raw_content = factory.Faker("paragraphs", nb=3)
+    email = factory.Faker("safe_email")
+    gender = factory.Faker("job")
+    location = factory.Faker("country")
+    nsfw = factory.Faker("pybool")
+    public_key = factory.Faker("sha1")
+    public = factory.Faker("pybool")
+    guid = factory.Faker("uuid4")
+    image_urls = {
+        "small": factory.Faker("image_url", width=30, height=30).generate({}),
+        "medium": factory.Faker("image_url", width=100, height=100).generate({}),
+        "large": factory.Faker("image_url", width=300, height=300).generate({}),
+    }
+    tag_list = factory.Faker("words", nb=4)


### PR DESCRIPTION
Remote profiles were so far only created on first encounter. Now we also process incoming ``Profile`` entities from the federation layer.