### PR TITLE
Add user API token view

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Added
 
   By default statistics is off. Admins can switch the counts on by setting environment variable ``SOCIALHOME_STATISTICS=True`` and restarting Socialhome.
 
+* Add user API token view. Allows retrieving an API token for usage in clients and tools. Allows also regenerating the token if it has been lost or exposed.
+
 0.3.1 (2017-08-06)
 ------------------
 

--- a/socialhome/streams/templates/streams/profile.html
+++ b/socialhome/streams/templates/streams/profile.html
@@ -16,6 +16,7 @@
                     <a class="dropdown-item" href="{% url "users:profile-update" %}" title="{% trans "Update profile" %}" aria-label="{% trans "Update profile" %}"><i class="fa fa-address-book"></i> {% trans "Update profile" %}</a>
                     <a class="dropdown-item" href="{% url "users:picture-update" %}" title="{% trans "Change picture" %}" aria-label="{% trans "Change picture" %}"><i class="fa fa-camera"></i> {% trans "Change picture" %}</a>
                     <a class="dropdown-item" href="{% url "dynamic_preferences.user" %}" title="{% trans "Preferences" %}" aria-label="{% trans "Preferences" %}"><i class="fa fa-cog"></i> {% trans "Preferences" %}</a>
+                    <a class="dropdown-item" href="{% url "users:api-token" %}" title="{% trans "API token" %}" aria-label="{% trans "API token" %}"><i class="fa fa-code"></i> {% trans "API token" %}</a>
                     <a class="dropdown-item" href="{% url "account_email" %}" title="{% trans "Email" %}" aria-label="{% trans "Email" %}"><i class="fa fa-envelope"></i> {% trans "Email" %}</a>
                     {% if content_list %}
                         <a class="dropdown-item" href="{% url "users:profile-organize" %}" title="{% trans "Organize profile content" %}" aria-label="{% trans "Organize profile content" %}"><i class="fa fa-arrows-v"></i> {% trans "Organize profile content" %}</a>

--- a/socialhome/users/templates/users/user_api_token.html
+++ b/socialhome/users/templates/users/user_api_token.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "API token" %}{% endblock %}
+
+{% block content %}
+    <h1>{% trans "API token" %}</h1>
+    <p>
+        {% trans "Copy the token to a client or tool which you want to use for interacting with your Socialhome account." %}
+    </p>
+    <p><strong>
+        {% trans "Important! Do not give anyone access to the token or they will be able to use your account through client apps! If you lose your token or need a new one, click 'Regenerate'." %}
+    </strong></p>
+    <form method="post">
+        {% csrf_token %}
+        <div class="row">
+            <div class="col-10 w-100">
+                <div class="form-group">
+                    <input class="form-control" type="text" placeholder="{{ token.key }}" value="{{ token.key }}" readonly onclick="this.select()">
+                </div>
+            </div>
+            <div class="col-2 w-100">
+                <div class="form-group">
+                    <input type="hidden" value="regenerate" name="regenerate" />
+                    <button class="form-control btn btn-danger" type="submit">{% trans "Regenerate" %}</button>
+                </div>
+            </div>
+        </div>
+        <div>
+            <a href="{% url "users:detail" username=request.user.username %}" class="btn btn-secondary">{% trans "Return to profile" %}</a>
+        </div>
+    </form>
+{% endblock %}

--- a/socialhome/users/urls.py
+++ b/socialhome/users/urls.py
@@ -24,6 +24,11 @@ urlpatterns = [
         name="picture-update"
     ),
     url(
+        regex=r"^u/~api-token/$",
+        view=views.UserAPITokenView.as_view(),
+        name="api-token",
+    ),
+    url(
         regex=r"^p/~organize/$",
         view=views.OrganizeContentProfileDetailView.as_view(),
         name="profile-organize"


### PR DESCRIPTION
Allows retrieving an API token for usage in clients and tools. Allows also regenerating the token if it has been lost or exposed.