### PR TITLE
Fix dump_content in Vue streams

### DIFF
--- a/socialhome/streams/views.py
+++ b/socialhome/streams/views.py
@@ -56,7 +56,7 @@ class BaseStreamView(ListView):
             }
 
         return {
-            "contentList": [dump_content(content) for content in self.queryset],
+            "contentList": [dump_content(content) for content in self.queryset[:self.paginate_by]],
             "currentBrowsingProfileId": getattr(request_user_profile, "id", ""),
             "streamName": stream_name,
             "isUserAuthentificated": bool(self.request.user.is_authenticated),


### PR DESCRIPTION
Only dump the "first page", not the whole queryset. Otherwise you just time out on large db's.

ping @christophehenry for review