### PR TITLE
Content API results now return `visibility` as a string

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,11 @@ Added
 
 * Add user API token view. Allows retrieving an API token for usage in clients and tools. Allows also regenerating the token if it has been lost or exposed.
 
+Changed
+.......
+
+* **Breaking change**. Content API results now return `visibility` as a string ('public', 'limited', 'site' or 'self'), not an integer.
+
 0.3.1 (2017-08-06)
 ------------------
 

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -6,7 +6,7 @@ from socialhome.enums import Visibility
 
 
 class ContentSerializer(ModelSerializer):
-    visibility = EnumField(Visibility, lenient=True)
+    visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
 
     class Meta:
         model = Content

--- a/socialhome/content/viewsets.py
+++ b/socialhome/content/viewsets.py
@@ -28,6 +28,14 @@ class CreateContentThrottle(UserRateThrottle):
 
 
 class ContentViewSet(ModelViewSet):
+    """
+    create:
+        Create content
+
+        Required values: `text` and `visibility`.
+
+        `visibility` should be one of: `public`, `site`, `limited`, `self`.
+    """
     queryset = Content.objects.none()
     serializer_class = ContentSerializer
     permission_classes = (IsOwnContentOrReadOnly,)


### PR DESCRIPTION
So 'public', 'limited', 'site' or 'self', not an integer.