### PR TITLE
Removed Content, Profile and Users API LIST routes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,11 @@ Changed
 
 * **Breaking change**. Content API results now return `visibility` as a string ('public', 'limited', 'site' or 'self'), not an integer.
 
+Removed
+.......
+
+* **Breaking change**. Removed Content, Profile and Users API LIST routes. For now these are seen as not required for building a client and allow unnecessarily easy data mining.
+
 0.3.1 (2017-08-06)
 ------------------
 

--- a/socialhome/content/tests/test_viewsets.py
+++ b/socialhome/content/tests/test_viewsets.py
@@ -32,22 +32,15 @@ class TestContentViewSet(SocialhomeAPITestCase, TestCase):
 
     def test_list_content(self):
         self.get("api:content-list")
-        self.response_200()
-        self.assertEqual(len(self.last_response.data["results"]), 1)
-        self.assertEqual(self.last_response.data["results"][0]["id"], self.public_content.id)
+        self.response_405()
 
         with self.login(self.user):
             self.get("api:content-list")
-            self.response_200()
-            self.assertEqual(len(self.last_response.data["results"]), 2)
-            self._check_result_ids({self.public_content.id, self.site_content.id})
+            self.response_405()
 
         with self.login(self.staff_user):
             self.get("api:content-list")
-            self.response_200()
-            self.assertEqual(len(self.last_response.data["results"]), 4)
-            self._check_result_ids({self.public_content.id, self.site_content.id, self.limited_content.id,
-                                    self.self_content.id})
+            self.response_405()
 
     def test_detail(self):
         self.get("api:content-detail", pk=self.public_content.id)

--- a/socialhome/content/viewsets.py
+++ b/socialhome/content/viewsets.py
@@ -1,6 +1,7 @@
+from rest_framework import mixins
 from rest_framework.permissions import BasePermission, SAFE_METHODS
 from rest_framework.throttling import UserRateThrottle
-from rest_framework.viewsets import ModelViewSet
+from rest_framework.viewsets import GenericViewSet
 
 from socialhome.content.models import Content
 from socialhome.content.serializers import ContentSerializer
@@ -27,7 +28,8 @@ class CreateContentThrottle(UserRateThrottle):
     scope = "content_create"
 
 
-class ContentViewSet(ModelViewSet):
+class ContentViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin, mixins.UpdateModelMixin,
+                     mixins.DestroyModelMixin, GenericViewSet):
     """
     create:
         Create content

--- a/socialhome/users/viewsets.py
+++ b/socialhome/users/viewsets.py
@@ -3,7 +3,7 @@ from rest_framework.decorators import detail_route
 from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.permissions import BasePermission, IsAuthenticated, SAFE_METHODS
 from rest_framework.response import Response
-from rest_framework.viewsets import ReadOnlyModelViewSet, GenericViewSet
+from rest_framework.viewsets import GenericViewSet
 
 from socialhome.enums import Visibility
 from socialhome.users.models import User, Profile
@@ -27,7 +27,7 @@ class IsOwnProfileOrReadOnly(BasePermission):
         return obj.user == request.user
 
 
-class ProfileViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.ListModelMixin, GenericViewSet):
+class ProfileViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, GenericViewSet):
     queryset = Profile.objects.none()
     serializer_class = ProfileSerializer
     permission_classes = (IsOwnProfileOrReadOnly,)
@@ -66,7 +66,7 @@ class ProfileViewSet(mixins.RetrieveModelMixin, mixins.UpdateModelMixin, mixins.
         return Response({"status": "Follower removed."})
 
 
-class UserViewSet(ReadOnlyModelViewSet):
+class UserViewSet(mixins.RetrieveModelMixin, GenericViewSet):
     queryset = User.objects.none()
     serializer_class = UserSerializer
     permission_classes = (IsAuthenticated,)


### PR DESCRIPTION
For now these are seen as not required for building a client and allow unnecessarily easy data mining.