### PR TITLE
Add 'share' action to Content API.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,8 @@ Added
 
 * There is now a 'My content' stream link in the navbar 'Streams' dropdown. This goes to your own profile all content stream.
 
+* Add ``share`` action to Content API. This enables creating shares via the API.  (`#206 <https://github.com/jaywink/socialhome/issues/206>`_)
+
 Changed
 .......
 

--- a/socialhome/content/tests/test_viewsets.py
+++ b/socialhome/content/tests/test_viewsets.py
@@ -192,3 +192,33 @@ class TestContentViewSet(SocialhomeAPITestCase, TestCase):
             self.post("api:content-list", data=data)
             content = Content.objects.get(id=self.last_response.data["id"])
             self.assertEqual(content.author_id, self.staff_user.profile.id)
+
+    def test_share(self):
+        self.post("api:content-share", pk=self.public_content.id)
+        self.response_403()
+        self.post("api:content-share", pk=self.site_content.id)
+        self.response_403()
+        self.post("api:content-share", pk=self.limited_content.id)
+        self.response_403()
+        self.post("api:content-share", pk=self.self_content.id)
+        self.response_403()
+
+        with self.login(self.user):
+            self.post("api:content-share", pk=self.public_content.id)
+            self.response_200()
+            self.post("api:content-share", pk=self.site_content.id)
+            self.response_200()
+            self.post("api:content-share", pk=self.limited_content.id)
+            self.response_404()
+            self.post("api:content-share", pk=self.self_content.id)
+            self.response_404()
+
+        with self.login(self.staff_user):
+            self.post("api:content-share", pk=self.public_content.id)
+            self.response_200()
+            self.post("api:content-share", pk=self.site_content.id)
+            self.response_200()
+            self.post("api:content-share", pk=self.limited_content.id)
+            self.response_400()
+            self.post("api:content-share", pk=self.self_content.id)
+            self.response_400()


### PR DESCRIPTION
This enables creating shares via the API.

Refs: #206