### PR TITLE
Add user preference for the new stream refactoring

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,10 @@ Added
 
 * There is now a 'My content' stream link in the navbar 'Streams' dropdown. This goes to your own profile all content stream.
 
+* Add user preference for the new stream refactoring. If enabled, all streams that have a new version in progress will be rendered with the new frontend code based on Vue.js. (`#202 <https://github.com/jaywink/socialhome/issues/202>`_)
+
+  Warning! The new frontent code doesn't have all the features of the current on yet.
+
 Changed
 .......
 

--- a/socialhome/streams/__init__.py
+++ b/socialhome/streams/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "socialhome.streams.apps.StreamsConfig"

--- a/socialhome/streams/app/components/StampedElement.vue
+++ b/socialhome/streams/app/components/StampedElement.vue
@@ -1,6 +1,11 @@
 <template>
     <div>
-        <h2>{{ $store.state.translations.stampedContent.h2 }}</h2>
+        <h2>
+            {{ $store.state.translations.stampedContent.h2 }}
+            <a href="/preferences/user/">
+                <span class="badge badge-default pull-right rounded-0">alpha</span>
+            </a>
+        </h2>
         <p>{{ $store.state.translations.stampedContent.p }}</p>
     </div>
 </template>

--- a/socialhome/streams/apps.py
+++ b/socialhome/streams/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class StreamsConfig(AppConfig):
+    name = "socialhome.streams"
+    verbose_name = "Streams"

--- a/socialhome/streams/preferences.py
+++ b/socialhome/streams/preferences.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext_lazy as _
+from dynamic_preferences.types import Section, BooleanPreference
+from dynamic_preferences.users.registries import user_preferences_registry
+
+streams = Section("streams")
+
+
+@user_preferences_registry.register
+class UseNewStream(BooleanPreference):
+    section = streams
+    name = "use_new_stream"
+    default = False
+    verbose_name = _("Use new stream")
+    help_text = _("Set this to use the new alpha stream when possible. Warning! Not all functionality is available "
+                  "in the new stream.")

--- a/socialhome/streams/views.py
+++ b/socialhome/streams/views.py
@@ -15,7 +15,10 @@ class BaseStreamView(ListView):
     vue = False
 
     def dispatch(self, request, *args, **kwargs):
-        self.vue = bool(request.GET.get("vue", False))
+        use_new_stream = (
+            hasattr(request.user, "preferences") and request.user.preferences.get("streams__use_new_stream")
+        )
+        self.vue = bool(request.GET.get("vue", False)) or use_new_stream
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
If enabled, all streams that have a new version in progress will be rendered with the new frontend code based on Vue.js.

Refs: #202