### PR TITLE
Rewrite find urls from content

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ Changed
 
 * Rendered link processing has been rewritten. This fixes issues with some links not being linkified when rendering. Additionally now all external links are made to open in a new tab or window. (`#197 <https://github.com/jaywink/socialhome/issues/197>`_)
 
+* Previously previews and oEmbed's for content used to only pick up "orphan" links from the content text. This meant that if there was a Markdown or HTML link, there would be no link preview or oEmbed fetched. This has now been changed. All links found in the content will be considered for preview and oEmbed. The first link to return a preview or oEmbed will be used.
+
 0.4.0 (2017-08-31)
 ------------------
 

--- a/socialhome/content/tests/test_utils.py
+++ b/socialhome/content/tests/test_utils.py
@@ -90,12 +90,13 @@ class TestFindUrlsInText(TestCase):
         cls.starts_with_url = "https://example.com/foobar"
         cls.http_starts_with_url = "http://example.com/foobar"
         cls.numbers = "http://foo123.633.com"
-        cls.special_chars = "https://example.com/~:[]@!$()*,;_%20+wat.wot?foo=bar&bar=foo#rokkenroll"
+        cls.special_chars = "https://example.com/~@!$()*,;_%20+wat.wot?foo=bar&bar=foo#rokkenroll"
         cls.urls_in_text = "fewfe https://example1.com grheiugheriu\nhttps://example2.com " \
                            "fhuiwehfui https://example-3.com\nfwfefewjuio"
         cls.href_and_markdown = "foo <a href='https://example.com'>bar</a> " \
-                                "<a href=\"https://example.com\">bar</a>" \
-                                "[waat](https://example.com)"
+                                "<a href=\"https://example.net\">bar</a>" \
+                                "[waat](https://example.org)"
+        cls.without_protocol = "example.org"
 
     def test_starts_with_url(self):
         urls = find_urls_in_text(self.starts_with_url)
@@ -117,9 +118,13 @@ class TestFindUrlsInText(TestCase):
             "https://example1.com", "https://example2.com", "https://example-3.com"
         ])
 
-    def test_href_markdown_etc_skipped(self):
+    def test_href_markdown(self):
         urls = find_urls_in_text(self.href_and_markdown)
-        self.assertEqual(urls, [])
+        self.assertEqual(urls, ["https://example.com", "https://example.net", "https://example.org"])
+
+    def test_without_protocol(self):
+        urls = find_urls_in_text(self.without_protocol)
+        self.assertEqual(urls, ["http://example.org"])
 
 
 class TestProcessTextLinks(TestCase):

--- a/socialhome/content/tests/test_utils.py
+++ b/socialhome/content/tests/test_utils.py
@@ -100,31 +100,31 @@ class TestFindUrlsInText(TestCase):
 
     def test_starts_with_url(self):
         urls = find_urls_in_text(self.starts_with_url)
-        self.assertEqual(urls, [self.starts_with_url])
+        self.assertEqual(urls, {self.starts_with_url})
         urls = find_urls_in_text(self.http_starts_with_url)
-        self.assertEqual(urls, [self.http_starts_with_url])
+        self.assertEqual(urls, {self.http_starts_with_url})
 
     def test_numbers(self):
         urls = find_urls_in_text(self.numbers)
-        self.assertEqual(urls, [self.numbers])
+        self.assertEqual(urls, {self.numbers})
 
     def test_special_chars(self):
         urls = find_urls_in_text(self.special_chars)
-        self.assertEqual(urls, [self.special_chars])
+        self.assertEqual(urls, {self.special_chars})
 
     def test_urls_in_text(self):
         urls = find_urls_in_text(self.urls_in_text)
-        self.assertEqual(urls, [
+        self.assertEqual(urls, {
             "https://example1.com", "https://example2.com", "https://example-3.com"
-        ])
+        })
 
     def test_href_markdown(self):
         urls = find_urls_in_text(self.href_and_markdown)
-        self.assertEqual(urls, ["https://example.com", "https://example.net", "https://example.org"])
+        self.assertEqual(urls, {"https://example.com", "https://example.net", "https://example.org"})
 
     def test_without_protocol(self):
         urls = find_urls_in_text(self.without_protocol)
-        self.assertEqual(urls, ["http://example.org"])
+        self.assertEqual(urls, {"http://example.org"})
 
 
 class TestProcessTextLinks(TestCase):

--- a/socialhome/content/utils.py
+++ b/socialhome/content/utils.py
@@ -101,14 +101,16 @@ def process_text_links(text):
 def find_urls_in_text(text):
     """Find url's from text.
 
-    URL matching by design only picks up "orphan" urls which are not href attributes or markdown links.
-    There must be an empty space, line feed or text start before the url for a match to happen.
-
-    Note, this is not entirely accurate, we're just trying to match as many as we can, allowing possibly
-    a few false positives.
+    Bleach does the heavy lifting here by identifying the links.
     """
-    urls = re.findall(r'^https?://[\w\./\?=#\-&_%\+~:\[\]@\!\$\(\)\*,;]*', text) + \
-           re.findall(r'(?<=[ \n]{1})https?://[\w\./\?=#\-&_%\+~:\[\]@\!\$\(\)\*,;]*', text)
+    urls = []
+
+    def link_collector(attrs, new=False):
+        href_key = (None, "href")
+        urls.append(attrs.get(href_key))
+        return None
+
+    bleach.linkify(text, callbacks=[link_collector], parse_email=False, skip_tags=["code"])
     return urls
 
 

--- a/socialhome/content/utils.py
+++ b/socialhome/content/utils.py
@@ -102,6 +102,9 @@ def find_urls_in_text(text):
     """Find url's from text.
 
     Bleach does the heavy lifting here by identifying the links.
+
+    :param text: Text to search links from
+    :returns: set of urls
     """
     urls = []
 
@@ -111,7 +114,7 @@ def find_urls_in_text(text):
         return None
 
     bleach.linkify(text, callbacks=[link_collector], parse_email=False, skip_tags=["code"])
-    return urls
+    return set(urls)
 
 
 def test_tag(tag):


### PR DESCRIPTION
Previously previews and oEmbed's for content used to only pick up "orphan" links from the content text. This meant that if there was a Markdown or HTML link, there would be no link preview or oEmbed fetched. This has now been changed. All links found in the content will be considered for preview and oEmbed. The first link to return a preview or oEmbed will be used.

Instead of custom regexp we now use the bleach library to find links for us.