### PR TITLE
Profile API field changes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -48,6 +48,20 @@ Changed
 
   Since lots of old content will point to the old URL's, there will be support for the legacy URL's until they are needed for something else in the future.
 
+* **Breaking change**. Profile API field changes:
+
+    * Added:
+
+        * ``url`` (Full URL of local profile)
+        * ``home_url`` (Full URL of remote profile, if remote user)
+        * ``is_local`` (Boolean, is user local)
+        * ``visibility`` (Profile visibility setting, either ``public``, ``limited``, ``site`` or ``self``. Editable to self)
+
+    * Removed:
+
+        * ``user``
+        * ``rsa_public_key``
+
 Fixed
 .....
 

--- a/socialhome/users/serializers.py
+++ b/socialhome/users/serializers.py
@@ -1,15 +1,41 @@
+from enumfields.drf import EnumField
 from rest_framework.serializers import ModelSerializer
 
+from socialhome.enums import Visibility
 from socialhome.users.models import User, Profile
 
 
 class ProfileSerializer(ModelSerializer):
+    visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
+
     class Meta:
         model = Profile
-        fields = ("id", "name", "user", "guid", "handle", "rsa_public_key", "image_url_large",
-                  "image_url_medium", "image_url_small", "location", "nsfw")
-        read_only_fields = ("id", "user", "guid", "handle", "rsa_public_key", "image_url_large",
-                            "image_url_medium", "image_url_small")
+        fields = (
+            "guid",
+            "handle",
+            "home_url",
+            "id",
+            "image_url_large",
+            "image_url_medium",
+            "image_url_small",
+            "is_local",
+            "location",
+            "name",
+            "nsfw",
+            "url",
+            "visibility",
+        )
+        read_only_fields = (
+            "guid",
+            "handle",
+            "home_url",
+            "id",
+            "image_url_large",
+            "image_url_medium",
+            "image_url_small",
+            "is_local",
+            "url",
+        )
 
 
 class UserSerializer(ModelSerializer):

--- a/socialhome/users/tests/test_models.py
+++ b/socialhome/users/tests/test_models.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 import factory
+from django.conf import settings
 from django.test import override_settings
 from federation.entities import base
 
@@ -86,7 +87,9 @@ class TestProfile(SocialhomeTestCase):
 
     def test_home_url(self):
         self.assertEqual(self.profile.home_url, self.profile.remote_url)
-        self.assertEqual(self.user.profile.home_url, self.user.profile.get_absolute_url())
+        self.assertEqual(
+            self.user.profile.home_url, "%s%s" % (settings.SOCIALHOME_URL, self.user.profile.get_absolute_url()),
+        )
 
     def test_name_or_handle(self):
         self.assertEqual(self.profile.name_or_handle, self.profile.name)

--- a/socialhome/users/tests/test_viewsets.py
+++ b/socialhome/users/tests/test_viewsets.py
@@ -134,17 +134,23 @@ class TestProfileViewSet(SocialhomeAPITestCase):
 
     def test_read_only_fields(self):
         self.client.login(username=self.user.username, password="password")
-        for field in ("id", "user", "guid", "handle", "rsa_public_key", "image_url_large",
-                      "image_url_medium", "image_url_small"):
+        for field in ("id", "guid", "handle", "image_url_large", "image_url_medium", "image_url_small", "is_local",
+                      "url", "home_url"):
             response = self.client.patch(reverse("api:profile-detail", kwargs={"pk": self.profile.id}), {field: "82"})
-            self.assertEqual(response.data.get(field), getattr(self.profile, field if field != "user" else "user_id"))
-        for field in ("name", "location", "nsfw"):
+            self.assertEqual(response.data.get(field), getattr(self.profile, field))
+        for field in ("name", "location", "nsfw", "visibility"):
+            if field == "nsfw":
+                value = not self.profile.nsfw
+            elif field == "visibility":
+                value = "public" if self.profile.visibility != Visibility.PUBLIC else "limited"
+            else:
+                value = "82"
             response = self.client.patch(
                 reverse("api:profile-detail", kwargs={"pk": self.profile.id}),
-                {field: "82" if field != "nsfw" else not getattr(self.profile, "nsfw")}
+                {field: value}
             )
             self.assertEqual(
-                str(response.data.get(field)), "82" if field != "nsfw" else str(not getattr(self.profile, "nsfw"))
+                response.data.get(field), value
             )
 
     def test_user_add_follower(self):


### PR DESCRIPTION
Required to build frontend using API data.

* Added:
    * ``url`` (Full URL of local profile)
    * ``home_url`` (Full URL of remote profile, if remote user)
    * ``is_local`` (Boolean, is user local)
    * ``visibility`` (Profile visibility setting, either ``public``, ``limited``, ``site`` or ``self``. Editable to self)

* Removed:
    * ``user``
    * ``rsa_public_key``

Refs: #194