### PR TITLE
Content API replies endpoint

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,6 +34,8 @@ Added
 
 * GIF uploads are now possible when creating content or replies. (`#125 <https://github.com/jaywink/socialhome/issues/125>`_)
 
+* Content API has a new endpoint ``/api/content/<id>/replies/``. This returns all the replies for the given content.
+
 Changed
 .......
 
@@ -43,8 +45,8 @@ Changed
 
 * Streams URL changes:
 
-    * All streams will now be under `/streams/` for a cleaner URL layout. So for example `/public/` is now `/streams/public/`.
-    * Tag stream URL has been changed from `/streams/tags/<tag>/` to `/streams/tag/<tag>/`. This small change allows us to later map `/stream/tags/` to the tags the user is following.
+    * All streams will now be under ``/streams/`` for a cleaner URL layout. So for example ``/public/`` is now ``/streams/public/``.
+    * Tag stream URL has been changed from ``/streams/tags/<tag>/`` to ``/streams/tag/<tag>/``. This small change allows us to later map ``/stream/tags/`` to the tags the user is following.
 
   Since lots of old content will point to the old URL's, there will be support for the legacy URL's until they are needed for something else in the future.
 


### PR DESCRIPTION
Content API has a new endpoint ``/api/content/<id>/replies/``. This returns all the replies for the given content.

Refs: #194