### PR TITLE
Content API now serializes limited author information

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -76,6 +76,12 @@ Changed
         * ``user_is_author`` (Boolean whether current user is the author of the content)
         * ``user_has_shared`` (Boolean whether current user has shared the content)
 
+    * Changed:
+
+        * ``author`` is now a limited serialization of the author profile, containing the following keys: "guid", "handle", "home_url", "id", "image_url_small", "is_local", "name", "url".
+
+          The reason for serializing the author information to content is related to privacy controls. A user who maintains a limited profile can still create public content, for example. A user who is able to view the content created by the user should also see some limited information about the creating profile. To get the full profile, the user needs to fetch the profile object by ID, which is subject to the visibility set by the profile owner.
+
     * Removed (internal attributes unnecessary for frontend rendering):
 
         * ``created``

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -5,9 +5,11 @@ from rest_framework.serializers import ModelSerializer
 from socialhome.content.enums import ContentType
 from socialhome.content.models import Content
 from socialhome.enums import Visibility
+from socialhome.users.serializers import LimitedProfileSerializer
 
 
 class ContentSerializer(ModelSerializer):
+    author = LimitedProfileSerializer(read_only=True)
     content_type = EnumField(ContentType, ints_as_names=True, read_only=True)
     user_following_author = SerializerMethodField()
     user_is_author = SerializerMethodField()

--- a/socialhome/content/tests/test_serializers.py
+++ b/socialhome/content/tests/test_serializers.py
@@ -22,6 +22,18 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         except AttributeError:
             pass
 
+    def test_serializes_author(self):
+        serializer = ContentSerializer(self.content)
+        data = serializer.data["author"]
+        self.assertEqual(data["guid"], self.remote_profile.guid)
+        self.assertEqual(data["handle"], self.remote_profile.handle)
+        self.assertEqual(data["home_url"], self.remote_profile.home_url)
+        self.assertEqual(data["id"], self.remote_profile.id)
+        self.assertEqual(data["image_url_small"], self.remote_profile.image_url_small)
+        self.assertEqual(data["is_local"], self.remote_profile.is_local)
+        self.assertEqual(data["name"], self.remote_profile.name)
+        self.assertEqual(data["url"], self.remote_profile.url)
+
     def test_user_following_author_false_if_no_request(self):
         serializer = ContentSerializer()
         self.assertFalse(serializer.get_user_following_author(None))

--- a/socialhome/users/serializers.py
+++ b/socialhome/users/serializers.py
@@ -5,6 +5,35 @@ from socialhome.enums import Visibility
 from socialhome.users.models import User, Profile
 
 
+class LimitedProfileSerializer(ModelSerializer):
+    """Read only Profile serializer with less information.
+
+    For example for adding to serialized Content.
+    """
+    class Meta:
+        model = Profile
+        fields = (
+            "guid",
+            "handle",
+            "home_url",
+            "id",
+            "image_url_small",
+            "is_local",
+            "name",
+            "url",
+        )
+        read_only_fields = (
+            "guid",
+            "handle",
+            "home_url",
+            "id",
+            "image_url_small",
+            "is_local",
+            "name",
+            "url",
+        )
+
+
 class ProfileSerializer(ModelSerializer):
     visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
 


### PR DESCRIPTION
``author`` is now a limited serialization of the author profile, containing the following keys: "guid", "handle", "home_url", "id", "image_url_small", "is_local", "name", "url".

The reason for serializing the author information to content is related to privacy controls. A user who maintains a limited profile will can still create public content, for example. A user who is able to view the content created by the user should also see some limited information about the creating profile. To get the full profile, the user needs to fetch the profile object by ID, which is subject to the visibility set by the profile owner.

Refs: #194