### PR TITLE
Don't federate shares to shared content local author

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,6 +93,7 @@ Fixed
 .....
 
 * Cycling browser tabs with CTRL-TAB when focused on the editor no longer inserts a TAB character in the editor.
+* Don't federate shares to shared content local author. This caused unnecessary deliveries between the same host.
 
 0.4.0 (2017-08-31)
 ------------------

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -136,11 +136,10 @@ def send_share(content_id):
         if settings.DEBUG:
             # Don't send in development mode
             return
-        recipients = [
+        recipients = _get_remote_followers(content.author)
+        if not content.share_of.local:
             # Send to original author
-            (content.share_of.author.handle, None),
-        ]
-        recipients.extend(_get_remote_followers(content.author))
+            recipients.append((content.share_of.author.handle, None))
         handle_send(entity, content.author, recipients)
     else:
         logger.warning("send_share - No entity for %s", content)


### PR DESCRIPTION
This caused unnecessary deliveries between the same host.