### PR TITLE
Refactoring for streams views to use new Stream classes

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -248,7 +248,7 @@ AUTOSLUG_SLUGIFY_FUNCTION = "slugify.slugify"
 REDIS_HOST = env("REDIS_HOST", default="localhost")
 REDIS_PORT = env("REDIS_PORT", default=6379)
 REDIS_DB = env("REDIS_DB", default=0)
-REDIS_PASSWORD = env("REDIS_PASSWORD", default="")
+REDIS_PASSWORD = env("REDIS_PASSWORD", default=None)
 
 # RQ
 # --

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -170,6 +170,7 @@ TEMPLATES = [
                 "django.template.context_processors.tz",
                 "django.contrib.messages.context_processors.messages",
                 "django_settings_export.settings_export",
+                "socialhome.context_processors.enums",
             ],
         },
     },

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -89,6 +89,12 @@ Changed
         * ``oembed``
         * ``opengraph``
 
+* Refactoring for streams views to use new Stream classes which support pre-caching of content ID's. No visible changes to user experience except a faster "Followed users" stream.
+
+  A stream class that is set as cached will store into Redis a list of content ID's for each user who would normally see that content in the stream. This allows pulling content out of the database very fast. If the stream is not cached or does not have cached content ID's, normal database lookups will be used.
+
+  This refactoring enables creating more complex streams which require heavier calculations to decide whether a content item should be in a stream or not.
+
 Fixed
 .....
 

--- a/socialhome/content/views.py
+++ b/socialhome/content/views.py
@@ -9,6 +9,7 @@ from django.views.generic import CreateView, UpdateView, DeleteView, DetailView
 from socialhome.content.enums import ContentType
 from socialhome.content.forms import ContentForm
 from socialhome.content.models import Content
+from socialhome.streams.enums import StreamType
 
 
 class ContentVisibleForUserMixin(UserPassesTestMixin):
@@ -149,5 +150,5 @@ class ContentView(ContentVisibleForUserMixin, AjaxResponseMixin, JSONResponseMix
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["stream_name"] = "content__%s" % self.object.channel_group_name
+        context["stream_name"] = "%s__%s" % (StreamType.CONTENT.value, self.object.channel_group_name)
         return context

--- a/socialhome/context_processors.py
+++ b/socialhome/context_processors.py
@@ -1,0 +1,10 @@
+from socialhome.streams.enums import StreamType
+
+
+def enums(request):
+    """Add some useful enums to the context."""
+    return {
+        "ENUMS": {
+            "StreamType": StreamType.to_dict(),
+        },
+    }

--- a/socialhome/streams/enums.py
+++ b/socialhome/streams/enums.py
@@ -1,0 +1,27 @@
+from django.utils.translation import ugettext_lazy as _
+from enumfields import Enum
+
+
+class StreamType(Enum):
+    CONTENT = "content"
+    CUSTOM = "custom"
+    FOLLOWED = "followed"
+    PROFILE_ALL = "profile_all"
+    PROFILE_PINNED = "profile_pinned"
+    PUBLIC = "public"
+    TAG = "tag"
+    TAGS = "tags"
+
+    class Labels:
+        CONTENT = _("Content")
+        CUSTOM = _("Custom")
+        FOLLOWED = _("Followed")
+        PROFILE_ALL = _("Profile (all)")
+        PROFILE_PINNED = _("Profile (pinned)")
+        PUBLIC = _("Public")
+        TAG = _("Tag")
+        TAGS = _("Tags")
+
+    @classmethod
+    def to_dict(cls):
+        return {i.name: i.value for i in cls}

--- a/socialhome/streams/streams.py
+++ b/socialhome/streams/streams.py
@@ -1,44 +1,168 @@
+import logging
+import time
+
+import django_rq
+from django.contrib.auth.models import AnonymousUser
+
+from socialhome.content.enums import ContentType
 from socialhome.content.models import Content
+from socialhome.streams.enums import StreamType
+from socialhome.users.models import User
+from socialhome.utils import get_redis_connection
+
+logger = logging.getLogger("socialhome")
+
+
+def add_to_redis(content, keys):
+    """Add content to a list of Redis ordered sets.
+
+    :param content: Content object to add
+    :param keys: List of keys to add to
+    """
+    if not keys:
+        return
+    r = get_redis_connection()
+    content_id = str(content.id)
+    for key in keys:
+        r.zadd(key, int(time.time()), content_id)
+
+
+def add_to_stream_for_users(content_id, stream_cls_name):
+    """Add content to all user streams of one type.
+
+    Excludes author of content.
+
+    This function is designed to be queued to RQ.
+    """
+    stream_cls = globals().get(stream_cls_name)
+    if stream_cls not in CACHED_STREAM_CLASSES:
+        return
+    try:
+        content = Content.objects.exclude(content_type=ContentType.REPLY).get(id=content_id)
+    except Content.DoesNotExist:
+        logger.warning("Stream.add_to_stream_for_users - content %s does not exist!", content_id)
+        return
+    qs = User.objects.filter(is_active=True)
+    if content.author.is_local:
+        qs = qs.exclude(id=content.author.user.id)
+    keys = []
+    # Cache for each active user
+    for user in qs.iterator():
+        keys = check_and_add_to_keys(stream_cls, user, content, keys)
+    # Cache also as anonymous user
+    if stream_cls in CACHED_ANONYMOUS_STREAM_CLASSES:
+        keys = check_and_add_to_keys(stream_cls, AnonymousUser(), content, keys)
+    add_to_redis(content, keys)
+
+
+def check_and_add_to_keys(stream_cls, user, content, keys):
+    """Check if content should be added to this user stream and add to the keys if so.
+
+    :returns: Existing keys with key added
+    """
+    # noinspection PyCallingNonCallable
+    stream = stream_cls(user=user)
+    if stream.should_cache_content(content):
+        keys.append(stream.get_key())
+    return keys
+
+
+def update_streams_with_content(content):
+    """Handle content adding to streams.
+
+    First adds to the author streams, then queues the rest of the user streams to a background job.
+    """
+    if content.content_type == ContentType.REPLY:
+        # No need to do these just now
+        return
+    # Do author immediately
+    if content.author.is_local:
+        user = content.author.user
+        keys = []
+        for stream_cls in CACHED_STREAM_CLASSES:
+            keys = check_and_add_to_keys(stream_cls, user, content, keys)
+        add_to_redis(content, keys)
+    # Queue rest to RQ
+    for stream_cls in CACHED_STREAM_CLASSES:
+        django_rq.enqueue(add_to_stream_for_users, content.id, stream_cls.__name__)
 
 
 class BaseStream:
     last_id = None
     ordering = "-created"
     paginate_by = 15
+    stream_type = None
 
     def __init__(self, last_id=None, user=None, **kwargs):
         self.last_id = last_id
         self.user = user
 
+    def __str__(self):
+        return "%s (%s)" % (self.__class__.__name__, self.user)
+
+    def get_cached_content_ids(self):
+        key = self.get_key()
+        r = get_redis_connection()
+        index = 0
+        if self.last_id:
+            last_index = r.zrevrank(key, self.last_id)
+            if not last_index:
+                # This item is outside our cached ids, abort
+                return []
+            index = last_index + 1
+        return r.zrevrange(key, index, index + self.paginate_by)
+
     def get_content(self):
         """Get queryset of Content objects."""
-        return Content.objects.filter(id__in=self.get_content_ids()).prefetch_related("tags").order_by(self.ordering)
+        return Content.objects.filter(id__in=self.get_content_ids())\
+            .select_related("author__user", "share_of").prefetch_related("tags").order_by(self.ordering)
 
     def get_content_ids(self):
         """Get a list of content ID's."""
+        ids = []
+        if self.__class__ in CACHED_STREAM_CLASSES:
+            ids = self.get_cached_content_ids()
+            if len(ids) >= self.paginate_by:
+                return ids
+        remaining = self.paginate_by - len(ids)
         qs = self.get_queryset()
         if self.last_id:
             if self.ordering == "-created":
                 qs = qs.filter(id__lt=self.last_id)
             else:
                 qs = qs.filter(id__gt=self.last_id)
-        return qs.values_list("id", flat=True).order_by(self.ordering)[:self.paginate_by]
+        ids.extend(qs.values_list("id", flat=True).order_by(self.ordering)[:remaining])
+        return ids
 
     def get_queryset(self):
         raise NotImplemented
 
+    def get_key(self):
+        if isinstance(self.user, AnonymousUser):
+            return "socialhome:streams:%s:anonymous" % self.stream_type.value
+        return "socialhome:streams:%s:%s" % (self.stream_type.value, self.user.id)
+
+    def should_cache_content(self, content):
+        return self.get_queryset().filter(id=content.id).exists()
+
 
 class FollowedStream(BaseStream):
+    stream_type = StreamType.FOLLOWED
+
     def get_queryset(self):
         return Content.objects.followed(self.user)
 
 
 class PublicStream(BaseStream):
+    stream_type = StreamType.PUBLIC
+
     def get_queryset(self):
         return Content.objects.public()
 
 
 class TagStream(BaseStream):
+    stream_type = StreamType.TAG
+
     def __init__(self, tag, **kwargs):
         super().__init__(**kwargs)
         self.tag = tag
@@ -47,3 +171,15 @@ class TagStream(BaseStream):
         if not self.tag:
             raise AttributeError("TagStream is missing tag.")
         return Content.objects.tag(self.tag, self.user)
+
+
+CACHED_STREAM_CLASSES = (
+    FollowedStream,
+    # TODO
+    # ProfileAllStream,
+)
+
+CACHED_ANONYMOUS_STREAM_CLASSES = (
+    # TODO
+    # ProfileAllStream,
+)

--- a/socialhome/streams/templates/streams/_grid_item.html
+++ b/socialhome/streams/templates/streams/_grid_item.html
@@ -2,12 +2,12 @@
 {% load i18n %}
 {% load string_utils %}
 
-<div class="grid-item {% if stream_name|startswith:"content_" %}grid-item-full{% endif %}" data-content-id="{{ content.id }}">
+<div class="grid-item {% if stream_name|startswith:ENUMS.StreamType.CONTENT %}grid-item-full{% endif %}" data-content-id="{{ content.id }}">
     {{ content.rendered|safe }}
-    {% if not stream_name|startswith:"profile_" %}
+    {% if not stream_name|startswith:ENUMS.StreamType.PROFILE_PINNED %}
         <div class="grid-item-author-bar mt-1">
             <div class="profile-box-trigger">
-                <img src="{{ content.author.safer_image_url_small }}" class="grid-item-author-bar-pic {% if stream_name|startswith:"content_" %}grid-item-author-bar-pic-large{% endif %}"> {% if content.author.name %}{{ content.author.name }}{% else %}{{ content.author.handle }}{% endif %}
+                <img src="{{ content.author.safer_image_url_small }}" class="grid-item-author-bar-pic {% if stream_name|startswith:ENUMS.StreamType.CONTENT %}grid-item-author-bar-pic-large{% endif %}"> {% if content.author.name %}{{ content.author.name }}{% else %}{{ content.author.handle }}{% endif %}
             </div>
             <div class="profile-box hidden">
                 {{ content.author.handle }}
@@ -59,7 +59,7 @@
     {% endif %}
     <div class="replies-container" data-content-id="{{ content.id }}"></div>
     {% if request.user.is_authenticated and content.content_type.string_value == "content" %}
-        <div class="content-actions reply-action {% if not stream_name|startswith:"content_" %}hidden{% endif %}" data-content-id="{{ content.id }}">
+        <div class="content-actions reply-action {% if not stream_name|startswith:ENUMS.StreamType.CONTENT %}hidden{% endif %}" data-content-id="{{ content.id }}">
             <a class="btn btn-secondary" href="{% url "content:reply" pk=content.id %}">{% trans "Reply" %}</a>
         </div>
     {% endif %}

--- a/socialhome/streams/tests/test_enums.py
+++ b/socialhome/streams/tests/test_enums.py
@@ -1,0 +1,12 @@
+from test_plus import TestCase
+
+from socialhome.streams.enums import StreamType
+
+
+class TestStreamType(TestCase):
+    def test_to_dict(self):
+        # noinspection PyTypeChecker
+        self.assertEqual(
+            StreamType.to_dict(),
+            {i.name: i.value for i in StreamType},
+        )

--- a/socialhome/streams/tests/test_streams.py
+++ b/socialhome/streams/tests/test_streams.py
@@ -1,13 +1,131 @@
-from unittest.mock import patch
+import random
+from unittest import skip
+from unittest.mock import patch, Mock, call
 
 from django.contrib.auth.models import AnonymousUser
+from django.db.models import Max
 
+from socialhome.content.enums import ContentType
 from socialhome.content.models import Content
 from socialhome.content.tests.factories import (
     ContentFactory, PublicContentFactory, SiteContentFactory, SelfContentFactory, LimitedContentFactory)
-from socialhome.streams.streams import BaseStream, FollowedStream, PublicStream, TagStream
+from socialhome.streams.enums import StreamType
+from socialhome.streams.streams import (
+    BaseStream, FollowedStream, PublicStream, TagStream, add_to_redis, add_to_stream_for_users,
+    update_streams_with_content, check_and_add_to_keys)
 from socialhome.tests.utils import SocialhomeTestCase
 from socialhome.users.tests.factories import UserFactory
+
+
+@patch("socialhome.streams.streams.get_redis_connection")
+@patch("socialhome.streams.streams.time.time", return_value=123.123)
+class TestAddToRedis(SocialhomeTestCase):
+    def test_adds_each_key(self, mock_time, mock_get):
+        mock_zadd = Mock()
+        mock_get.return_value = Mock(zadd=mock_zadd)
+        add_to_redis(Mock(id=1), ["spam", "eggs"])
+        calls = [
+            call("spam", 123, "1"),
+            call("eggs", 123, "1"),
+        ]
+        self.assertEqual(mock_zadd.call_args_list, calls)
+
+    def test_returns_on_no_keys(self, mock_time, mock_get):
+        mock_zadd = Mock()
+        mock_get.return_value = Mock(zadd=mock_zadd)
+        add_to_redis(Mock(), [])
+
+
+class TestAddToStreamForUsers(SocialhomeTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.create_local_and_remote_user()
+        cls.content = PublicContentFactory()
+        cls.profile.following.add(cls.content.author)
+        cls.limited_content = LimitedContentFactory()
+        cls.reply = PublicContentFactory(parent=cls.content)
+
+    @patch("socialhome.streams.streams.add_to_redis")
+    def test_calls_add_to_redis(self, mock_add):
+        add_to_stream_for_users(self.content.id, "FollowedStream")
+        stream = FollowedStream(user=self.user)
+        mock_add.assert_called_once_with(self.content, [stream.get_key()])
+
+    @patch("socialhome.streams.streams.check_and_add_to_keys")
+    @patch("socialhome.streams.streams.CACHED_ANONYMOUS_STREAM_CLASSES", new=tuple())
+    def test_calls_check_and_add_to_keys_for_each_user(self, mock_check):
+        add_to_stream_for_users(self.content.id, "FollowedStream")
+        mock_check.assert_called_once_with(FollowedStream, self.user, self.content, [])
+
+    @skip("Add when anonymous user cached streams exist")
+    @patch("socialhome.streams.streams.check_and_add_to_keys")
+    def test_includes_anonymous_user_for_anonymous_user_streams(self, mock_check):
+        add_to_stream_for_users(self.content.id, "ProfileAllStream", profile=self.profile)
+        anon_call = mock_check.call_args_list[1]
+        self.assertTrue(isinstance(anon_call[1], AnonymousUser))
+
+    @patch("socialhome.streams.streams.Content.objects.filter")
+    def test_returns_on_no_content_or_reply(self, mock_filter):
+        add_to_stream_for_users(Content.objects.aggregate(max_id=Max("id")).get("max_id") + 1, PublicStream)
+        self.assertFalse(mock_filter.called)
+        add_to_stream_for_users(self.reply.id, PublicStream)
+        self.assertFalse(mock_filter.called)
+
+    @patch("socialhome.streams.streams.check_and_add_to_keys", return_value=True)
+    def test_skips_if_not_cached_stream(self, mock_get):
+        add_to_stream_for_users(self.content.id, "SpamStream")
+        self.assertFalse(mock_get.called)
+        add_to_stream_for_users(self.content.id, "PublicStream")
+        self.assertFalse(mock_get.called)
+
+
+class TestCheckAndAddToKeys(SocialhomeTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.create_local_and_remote_user()
+        cls.profile.following.add(cls.remote_profile)
+        cls.content = PublicContentFactory()
+        cls.remote_content = PublicContentFactory(author=cls.remote_profile)
+
+    def test_adds_if_should_cache(self):
+        self.assertEqual(
+            check_and_add_to_keys(FollowedStream, self.user, self.remote_content, []),
+            ["socialhome:streams:followed:%s" % self.user.id],
+        )
+
+    def test_does_not_add_if_shouldnt_cache(self):
+        self.assertEqual(
+            check_and_add_to_keys(FollowedStream, self.user, self.content, []),
+            [],
+        )
+
+
+class TestUpdateStreamsWithContent(SocialhomeTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.create_local_and_remote_user()
+        cls.content = PublicContentFactory(author=cls.profile)
+        cls.remote_content = PublicContentFactory()
+
+    @patch("socialhome.streams.streams.django_rq.enqueue")
+    @patch("socialhome.streams.streams.add_to_redis")
+    @patch("socialhome.streams.streams.CACHED_STREAM_CLASSES", new=(FollowedStream, PublicStream))
+    def test_adds_with_local_user(self, mock_add, mock_enqueue):
+        update_streams_with_content(self.remote_content)
+        self.assertFalse(mock_add.called)
+        update_streams_with_content(self.content)
+        mock_add.assert_called_once_with(self.content, ["socialhome:streams:public:%s" % self.user.id])
+
+    @patch("socialhome.streams.streams.django_rq.enqueue")
+    def test_enqueues_each_stream_to_rq(self, mock_enqueue):
+        update_streams_with_content(self.content)
+        mock_enqueue.assert_called_once_with(add_to_stream_for_users, self.content.id, "FollowedStream")
+
+    def test_returns_if_reply(self):
+        self.assertIsNone(update_streams_with_content(Mock(content_type=ContentType.REPLY)))
 
 
 @patch("socialhome.streams.streams.BaseStream.get_queryset", return_value=Content.objects.all())
@@ -15,12 +133,43 @@ class TestBaseStream(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        cls.user = UserFactory()
         cls.content1 = ContentFactory()
         cls.content2 = ContentFactory()
 
     def setUp(self):
         super().setUp()
-        self.stream = BaseStream()
+        self.stream = BaseStream(user=self.user)
+
+    def test___str__(self, mock_queryset):
+        self.assertEqual(str(self.stream), "BaseStream (%s)" % str(self.user))
+
+    @patch("socialhome.streams.streams.get_redis_connection")
+    def test_get_cached_content_ids__calls(self, mock_get, mock_queryset):
+        mock_redis = Mock()
+        mock_get.return_value = mock_redis
+        self.stream.stream_type = StreamType.PUBLIC
+        self.stream.get_cached_content_ids()
+        # Skips zrevrank if not last_id
+        self.assertFalse(mock_redis.zrevrank.called)
+        # Calls zrevrange with correct parameters
+        mock_redis.zrevrange.assert_called_once_with(self.stream.get_key(), 0, self.stream.paginate_by)
+        mock_redis.reset_mock()
+        # Calls zrevrank with last_id
+        self.stream.last_id = self.content2.id
+        mock_redis.zrevrank.return_value = 3
+        self.stream.get_cached_content_ids()
+        mock_redis.zrevrank.assert_called_once_with(self.stream.get_key(), self.content2.id)
+        mock_redis.zrevrange.assert_called_once_with(self.stream.get_key(), 4, 4 + self.stream.paginate_by)
+
+    @patch("socialhome.streams.streams.get_redis_connection")
+    def test_get_cached_content_ids__returns_empty_list_if_outside_cached_ids(self, mock_get, mock_queryset):
+        mock_redis = Mock(zrevrank=Mock(return_value=None))
+        mock_get.return_value = mock_redis
+        self.stream.stream_type = StreamType.PUBLIC
+        self.stream.last_id = 123
+        self.assertEqual(self.stream.get_cached_content_ids(), [])
+        self.assertFalse(mock_redis.zrevrange.called)
 
     def test_get_content(self, mock_queryset):
         self.assertEqual([self.content2, self.content1], list(self.stream.get_content()))
@@ -54,6 +203,13 @@ class TestBaseStream(SocialhomeTestCase):
         self.assertEqual(stream.last_id, 333)
         self.assertEqual(stream.user, "user")
 
+    def test_should_cache_content(self, mock_queryset):
+        self.assertTrue(self.stream.should_cache_content(self.content1))
+        self.assertTrue(self.stream.should_cache_content(self.content2))
+        mock_queryset.return_value = Content.objects.none()
+        self.assertFalse(self.stream.should_cache_content(self.content1))
+        self.assertFalse(self.stream.should_cache_content(self.content2))
+
 
 class TestFollowedStream(SocialhomeTestCase):
     @classmethod
@@ -62,7 +218,7 @@ class TestFollowedStream(SocialhomeTestCase):
         cls.create_local_and_remote_user()
         cls.remote_profile.followers.add(cls.profile)
         cls.create_content_set(author=cls.remote_profile)
-        PublicContentFactory()
+        cls.other_public_content = PublicContentFactory()
         SiteContentFactory()
         SelfContentFactory()
         LimitedContentFactory()
@@ -70,6 +226,22 @@ class TestFollowedStream(SocialhomeTestCase):
     def setUp(self):
         super().setUp()
         self.stream = FollowedStream(user=self.user)
+
+    def test_get_content_ids_uses_cached_ids(self):
+        with patch.object(self.stream, "get_cached_content_ids") as mock_cached:
+            self.stream.get_content_ids()
+            mock_cached.assert_called_once_with()
+
+    def test_get_content_ids_fills_in_non_cached_content_up_to_pagination_amount(self):
+        with patch.object(self.stream, "get_cached_content_ids") as mock_cached:
+            cached_ids = random.sample(range(10000, 100000), self.stream.paginate_by - 1)
+            mock_cached.return_value = cached_ids
+            # Fills up with one of the two that are available
+            all_ids = set(cached_ids + [self.site_content.id])
+            self.assertEqual(set(self.stream.get_content_ids()), all_ids)
+
+    def test_get_key(self):
+        self.assertEqual(self.stream.get_key(), "socialhome:streams:followed:%s" % self.user.id)
 
     def test_only_followed_profile_content_returned(self):
         self.assertEqual(
@@ -82,22 +254,46 @@ class TestFollowedStream(SocialhomeTestCase):
         with self.assertRaises(AttributeError):
             self.stream.get_content()
 
+    def test_should_cache_content(self):
+        self.assertTrue(self.stream.should_cache_content(self.public_content))
+        self.assertTrue(self.stream.should_cache_content(self.site_content))
+        self.assertFalse(self.stream.should_cache_content(self.limited_content))
+        self.assertFalse(self.stream.should_cache_content(self.self_content))
+        self.assertFalse(self.stream.should_cache_content(self.other_public_content))
+
 
 class TestPublicStream(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
+        cls.user = UserFactory()
         cls.create_content_set()
 
     def setUp(self):
         super().setUp()
-        self.stream = PublicStream()
+        self.stream = PublicStream(user=self.user)
+
+    def test_get_content_ids_does_not_use_cached_ids(self):
+        with patch.object(self.stream, "get_cached_content_ids") as mock_cached:
+            self.stream.get_content_ids()
+            self.assertFalse(mock_cached.called)
+
+    def test_get_key(self):
+        self.assertEqual(self.stream.get_key(), "socialhome:streams:public:%s" % self.user.id)
+        stream = PublicStream(user=AnonymousUser())
+        self.assertEqual(stream.get_key(), "socialhome:streams:public:anonymous")
 
     def test_only_public_content_returned(self):
         self.assertEqual(
             {self.public_content},
             set(self.stream.get_content()),
         )
+
+    def test_should_cache_content(self):
+        self.assertTrue(self.stream.should_cache_content(self.public_content))
+        self.assertFalse(self.stream.should_cache_content(self.site_content))
+        self.assertFalse(self.stream.should_cache_content(self.limited_content))
+        self.assertFalse(self.stream.should_cache_content(self.self_content))
 
 
 class TestTagStream(SocialhomeTestCase):
@@ -118,6 +314,16 @@ class TestTagStream(SocialhomeTestCase):
         self.stream = TagStream(tag=self.tag, user=self.user)
         self.anon_stream = TagStream(tag=self.tag, user=AnonymousUser())
         self.local_stream = TagStream(tag=self.tag, user=self.local_user)
+
+    def test_get_content_ids_does_not_use_cached_ids(self):
+        with patch.object(self.stream, "get_cached_content_ids") as mock_cached:
+            self.stream.get_content_ids()
+            self.assertFalse(mock_cached.called)
+
+    def test_get_key(self):
+        self.assertEqual(self.stream.get_key(), "socialhome:streams:tag:%s" % self.user.id)
+        stream = PublicStream(user=AnonymousUser())
+        self.assertEqual(stream.get_key(), "socialhome:streams:public:anonymous")
 
     def test_only_tagged_content_returned(self):
         self.assertEqual(
@@ -142,3 +348,32 @@ class TestTagStream(SocialhomeTestCase):
         self.stream.tag = None
         with self.assertRaises(AttributeError):
             self.stream.get_content()
+
+    def test_should_cache_content(self):
+        # self.user stream
+        self.assertTrue(self.stream.should_cache_content(self.public_tagged))
+        self.assertTrue(self.stream.should_cache_content(self.site_tagged))
+        self.assertTrue(self.stream.should_cache_content(self.limited_tagged))
+        self.assertTrue(self.stream.should_cache_content(self.self_tagged))
+        self.assertFalse(self.stream.should_cache_content(self.public_content))
+        self.assertFalse(self.stream.should_cache_content(self.site_content))
+        self.assertFalse(self.stream.should_cache_content(self.limited_content))
+        self.assertFalse(self.stream.should_cache_content(self.self_content))
+        # anon stream
+        self.assertTrue(self.anon_stream.should_cache_content(self.public_tagged))
+        self.assertFalse(self.anon_stream.should_cache_content(self.site_tagged))
+        self.assertFalse(self.anon_stream.should_cache_content(self.limited_tagged))
+        self.assertFalse(self.anon_stream.should_cache_content(self.self_tagged))
+        self.assertFalse(self.anon_stream.should_cache_content(self.public_content))
+        self.assertFalse(self.anon_stream.should_cache_content(self.site_content))
+        self.assertFalse(self.anon_stream.should_cache_content(self.limited_content))
+        self.assertFalse(self.anon_stream.should_cache_content(self.self_content))
+        # self.local_user stream
+        self.assertTrue(self.local_stream.should_cache_content(self.public_tagged))
+        self.assertTrue(self.local_stream.should_cache_content(self.site_tagged))
+        self.assertFalse(self.local_stream.should_cache_content(self.limited_tagged))
+        self.assertFalse(self.local_stream.should_cache_content(self.self_tagged))
+        self.assertFalse(self.local_stream.should_cache_content(self.public_content))
+        self.assertFalse(self.local_stream.should_cache_content(self.site_content))
+        self.assertFalse(self.local_stream.should_cache_content(self.limited_content))
+        self.assertFalse(self.local_stream.should_cache_content(self.self_content))

--- a/socialhome/streams/tests/test_views.py
+++ b/socialhome/streams/tests/test_views.py
@@ -1,14 +1,15 @@
 from django.core.urlresolvers import reverse
-from django.test import Client, TestCase
+from django.test import Client, RequestFactory
 
 from socialhome.content.tests.factories import ContentFactory, TagFactory
 from socialhome.enums import Visibility
 from socialhome.streams.enums import StreamType
-from socialhome.tests.utils import SocialhomeTestCase
+from socialhome.streams.views import PublicStreamView, TagStreamView, FollowedStreamView
+from socialhome.tests.utils import SocialhomeCBVTestCase
 from socialhome.users.tests.factories import UserFactory
 
 
-class TestPublicStreamView(TestCase):
+class TestPublicStreamView(SocialhomeCBVTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -28,6 +29,14 @@ class TestPublicStreamView(TestCase):
         assert response.status_code == 200
         assert self.content.text in str(response.content)
 
+    def test_stream_name(self):
+        view = self.get_instance(PublicStreamView)
+        self.assertEqual(view.stream_name, StreamType.PUBLIC.value)
+
+    def test_stream_type_value(self):
+        view = self.get_instance(PublicStreamView)
+        self.assertEqual(view.stream_type_value, StreamType.PUBLIC.value)
+
     def test_uses_correct_template(self):
         response = self.client.get(reverse("streams:public"))
         template_names = [template.name for template in response.templates]
@@ -46,7 +55,7 @@ class TestPublicStreamView(TestCase):
         assert response.status_code == 200
 
 
-class TestTagStreamView(TestCase):
+class TestTagStreamView(SocialhomeCBVTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -69,6 +78,17 @@ class TestTagStreamView(TestCase):
         assert response.status_code == 200
         assert self.content.rendered in str(response.content)
 
+    def test_stream_name(self):
+        view = self.get_instance(TagStreamView)
+        view.tag = self.content.tags.first()
+        self.assertEqual(
+            view.stream_name, "%s__%s" % (StreamType.TAG.value, view.tag.channel_group_name)
+        )
+
+    def test_stream_type_value(self):
+        view = self.get_instance(TagStreamView)
+        self.assertEqual(view.stream_type_value, StreamType.TAG.value)
+
     def test_uses_correct_template(self):
         response = self.client.get(reverse("streams:tag", kwargs={"name": "tagnocontent"}))
         template_names = [template.name for template in response.templates]
@@ -86,7 +106,7 @@ class TestTagStreamView(TestCase):
         assert limited.rendered not in str(response.content)
 
 
-class TestFollowedStreamView(SocialhomeTestCase):
+class TestFollowedStreamView(SocialhomeCBVTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -96,29 +116,37 @@ class TestFollowedStreamView(SocialhomeTestCase):
         cls.other_content = ContentFactory(visibility=Visibility.PUBLIC)
         cls.user.profile.following.add(cls.content.author)
 
-    def test_context_data_is_ok(self):
-        with self.login(self.user):
-            self.get("streams:followed")
-        self.assertContext("stream_name", "%s__%s" % (StreamType.FOLLOWED.value, self.user.username))
+    @staticmethod
+    def get_request(user):
+        request = RequestFactory().get("/")
+        request.user = user
+        return request
 
     def test_renders_without_content(self):
-        with self.login(self.user2):
-            response = self.get("streams:followed")
-        self.assertContains(response, "Followed")
-        self.assertEquals(len(response.context["content_list"]), 0)
-        self.assertEquals(response.status_code, 200)
+        self.get(FollowedStreamView, request=self.get_request(self.user2))
+        self.assertContains(self.last_response, "Followed")
+        self.assertEquals(len(self.context["content_list"]), 0)
+        self.response_200()
 
     def test_renders_with_content(self):
-        with self.login(self.user):
-            response = self.get("streams:followed")
+        response = self.get(FollowedStreamView, request=self.get_request(self.user))
         self.assertContains(response, "Followed")
         self.assertIsNotNone(response.context["content_list"])
         self.assertEquals(set(response.context["content_list"]), {self.content})
         self.assertEquals(response.status_code, 200)
 
+    def test_stream_name(self):
+        view = self.get_instance(FollowedStreamView, request=self.get_request(self.user))
+        self.assertEqual(
+            view.stream_name, "%s__%s" % (StreamType.FOLLOWED.value, self.user.username)
+        )
+
+    def test_stream_type_value(self):
+        view = self.get_instance(FollowedStreamView)
+        self.assertEqual(view.stream_type_value, StreamType.FOLLOWED.value)
+
     def test_uses_correct_template(self):
-        with self.login(self.user):
-            response = self.get("streams:followed")
+        response = self.get(FollowedStreamView, request=self.get_request(self.user))
         template_names = [template.name for template in response.templates]
         assert "streams/followed.html" in template_names
 

--- a/socialhome/streams/tests/test_views.py
+++ b/socialhome/streams/tests/test_views.py
@@ -3,6 +3,7 @@ from django.test import Client, TestCase
 
 from socialhome.content.tests.factories import ContentFactory, TagFactory
 from socialhome.enums import Visibility
+from socialhome.streams.enums import StreamType
 from socialhome.tests.utils import SocialhomeTestCase
 from socialhome.users.tests.factories import UserFactory
 
@@ -98,7 +99,7 @@ class TestFollowedStreamView(SocialhomeTestCase):
     def test_context_data_is_ok(self):
         with self.login(self.user):
             self.get("streams:followed")
-        self.assertContext("stream_name", "followed__%s" % self.user.username)
+        self.assertContext("stream_name", "%s__%s" % (StreamType.FOLLOWED.value, self.user.username))
 
     def test_renders_without_content(self):
         with self.login(self.user2):

--- a/socialhome/streams/views.py
+++ b/socialhome/streams/views.py
@@ -3,6 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import ListView
 
 from socialhome.content.models import Content, Tag
+from socialhome.streams.enums import StreamType
 
 
 class BaseStreamView(ListView):
@@ -68,7 +69,7 @@ class BaseStreamView(ListView):
 class PublicStreamView(BaseStreamView):
     template_name = "streams/public.html"
     queryset = Content.objects.public()
-    stream_name = "public"
+    stream_name = StreamType.PUBLIC.value
 
 
 class TagStreamView(BaseStreamView):
@@ -76,7 +77,7 @@ class TagStreamView(BaseStreamView):
 
     def dispatch(self, request, *args, **kwargs):
         self.tag = get_object_or_404(Tag, name=kwargs.get("name"))
-        self.stream_name = "tag__%s" % self.tag.channel_group_name
+        self.stream_name = "%s__%s" % (StreamType.TAG.value, self.tag.channel_group_name)
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
@@ -95,7 +96,7 @@ class FollowedStreamView(LoginRequiredMixin, BaseStreamView):
     template_name = "streams/followed.html"
 
     def dispatch(self, request, *args, **kwargs):
-        self.stream_name = "followed__%s" % request.user.username
+        self.stream_name = "%s__%s" % (StreamType.FOLLOWED.value, request.user.username)
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):

--- a/socialhome/streams/views.py
+++ b/socialhome/streams/views.py
@@ -3,14 +3,15 @@ from django.shortcuts import get_object_or_404
 from django.views.generic import ListView
 
 from socialhome.content.models import Content, Tag
-from socialhome.streams.enums import StreamType
+from socialhome.streams.streams import PublicStream, FollowedStream, TagStream
 
 
 class BaseStreamView(ListView):
+    last_id = None
     model = Content
     ordering = "-created"
-    paginate_by = 30
-    stream_name = ""
+    paginate_by = 15
+    stream_class = None
     vue = False
 
     def dispatch(self, request, *args, **kwargs):
@@ -18,6 +19,7 @@ class BaseStreamView(ListView):
             hasattr(request.user, "preferences") and request.user.preferences.get("streams__use_new_stream")
         )
         self.vue = bool(request.GET.get("vue", False)) or use_new_stream
+        self.last_id = request.GET.get("last_id")
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
@@ -62,27 +64,38 @@ class BaseStreamView(ListView):
             "isUserAuthenticated": bool(self.request.user.is_authenticated),
         }
 
+    def get_queryset(self):
+        stream = self.stream_class(last_id=self.last_id, user=self.request.user)
+        return stream.get_content()
+
     def get_template_names(self):
         return ["streams/vue.html"] if self.vue else super().get_template_names()
+
+    @property
+    def stream_name(self):
+        return self.stream_type_value
+
+    @property
+    def stream_type_value(self):
+        return self.stream_class.stream_type.value
 
 
 class PublicStreamView(BaseStreamView):
     template_name = "streams/public.html"
-    queryset = Content.objects.public()
-    stream_name = StreamType.PUBLIC.value
+    stream_class = PublicStream
 
 
 class TagStreamView(BaseStreamView):
+    stream_class = TagStream
     template_name = "streams/tag.html"
 
     def dispatch(self, request, *args, **kwargs):
         self.tag = get_object_or_404(Tag, name=kwargs.get("name"))
-        self.stream_name = "%s__%s" % (StreamType.TAG.value, self.tag.channel_group_name)
         return super().dispatch(request, *args, **kwargs)
 
     def get_queryset(self):
-        """Restrict to a tag."""
-        return Content.objects.tag(self.tag, self.request.user)
+        stream = self.stream_class(last_id=self.last_id, user=self.request.user, tag=self.tag)
+        return stream.get_content()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -91,13 +104,15 @@ class TagStreamView(BaseStreamView):
             context["json_context"]["tagName"] = self.tag.name
         return context
 
+    @property
+    def stream_name(self):
+        return "%s__%s" % (self.stream_type_value, self.tag.channel_group_name)
+
 
 class FollowedStreamView(LoginRequiredMixin, BaseStreamView):
+    stream_class = FollowedStream
     template_name = "streams/followed.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        self.stream_name = "%s__%s" % (StreamType.FOLLOWED.value, request.user.username)
-        return super().dispatch(request, *args, **kwargs)
-
-    def get_queryset(self):
-        return Content.objects.followed(self.request.user)
+    @property
+    def stream_name(self):
+        return "%s__%s" % (self.stream_type_value, self.request.user.username)

--- a/socialhome/tests/environment.py
+++ b/socialhome/tests/environment.py
@@ -1,5 +1,12 @@
-import requests
 from unittest.mock import Mock
+
+import redis
+import requests
+
+
+class MockRedis(Mock):
+    def zrevrange(self, *args, **kwargs):
+        return []
 
 
 class MockResponse(str):
@@ -18,3 +25,7 @@ requests.post = Mock()
 requests.patch = Mock()
 requests.delete = Mock()
 requests.put = Mock()
+
+
+# Disable redis connection
+redis.StrictRedis = Mock(return_value=MockRedis())

--- a/socialhome/tests/test_context_processors.py
+++ b/socialhome/tests/test_context_processors.py
@@ -1,0 +1,18 @@
+from unittest.mock import Mock
+
+from test_plus import TestCase
+
+from socialhome.context_processors import enums
+from socialhome.streams.enums import StreamType
+
+
+class TestEnums(TestCase):
+    def test_enums(self):
+        self.assertEqual(
+            enums(Mock()),
+            {
+                "ENUMS": {
+                    "StreamType": StreamType.to_dict(),
+                },
+            },
+        )

--- a/socialhome/tests/test_environment.py
+++ b/socialhome/tests/test_environment.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+import redis
 import requests
 
 from socialhome.tests.utils import SocialhomeTestCase
@@ -12,3 +13,6 @@ class TestEnvironment(SocialhomeTestCase):
         self.assertTrue(isinstance(requests.post, Mock))
         self.assertTrue(isinstance(requests.patch, Mock))
         self.assertTrue(isinstance(requests.delete, Mock))
+
+    def test_redis(self):
+        self.assertTrue(isinstance(redis.StrictRedis, Mock))

--- a/socialhome/tests/test_utils.py
+++ b/socialhome/tests/test_utils.py
@@ -1,7 +1,10 @@
+from unittest.mock import patch
+
 from django.conf import settings
+from test_plus import TestCase
 
 from socialhome.tests.utils import SocialhomeTestCase
-from socialhome.utils import get_full_media_url
+from socialhome.utils import get_full_media_url, get_redis_connection
 
 
 class TestGetFullMediaUrl(SocialhomeTestCase):
@@ -10,3 +13,10 @@ class TestGetFullMediaUrl(SocialhomeTestCase):
             get_full_media_url("foobar"),
             "%s%s%s" % (settings.SOCIALHOME_URL, settings.MEDIA_URL, "foobar"),
         )
+
+
+class TestGetRedisConnection(TestCase):
+    @patch("socialhome.utils.redis.StrictRedis")
+    def test_get_redis_connection(self, mock_redis):
+        get_redis_connection()
+        self.assertTrue(mock_redis.called)

--- a/socialhome/users/tests/test_views.py
+++ b/socialhome/users/tests/test_views.py
@@ -7,6 +7,7 @@ from rest_framework.authtoken.models import Token
 from socialhome.content.models import Content
 from socialhome.content.tests.factories import ContentFactory
 from socialhome.enums import Visibility
+from socialhome.streams.enums import StreamType
 from socialhome.tests.utils import SocialhomeTestCase
 from socialhome.users.models import User, Profile
 from socialhome.users.tables import FollowedTable
@@ -340,14 +341,18 @@ class TestProfileAllContentView(SocialhomeTestCase):
         ContentFactory(author=self.user.profile, pinned=True, visibility=Visibility.PUBLIC)
         response = self.get("users:profile-all-content", guid=self.user.profile.guid)
         self.assertTrue(response.context_data.get("pinned_content_exists"))
-        self.assertEqual(response.context_data.get("stream_name"), "profile_all__%s" % self.user.profile.id)
+        self.assertEqual(
+            response.context_data.get("stream_name"), "%s__%s" % (StreamType.PROFILE_ALL.value, self.user.profile.id),
+        )
         self.assertEqual(response.context_data.get("profile_stream_type"), "all_content")
 
     def test_renders_for_remote_profile(self):
         response = self.get("users:profile-all-content", guid=self.profile.guid)
         self.assertEqual(response.status_code, 200)
         self.assertFalse(response.context_data.get("pinned_content_exists"))
-        self.assertEqual(response.context_data.get("stream_name"), "profile_all__%s" % self.profile.id)
+        self.assertEqual(
+            response.context_data.get("stream_name"), "%s__%s" % (StreamType.PROFILE_ALL.value, self.profile.id),
+        )
         self.assertEqual(response.context_data.get("profile_stream_type"), "all_content")
 
 

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -6,6 +6,7 @@ from django.views.generic import DetailView, ListView, UpdateView, TemplateView
 from rest_framework.authtoken.models import Token
 
 from socialhome.content.models import Content
+from socialhome.streams.enums import StreamType
 from socialhome.users.forms import ProfileForm, UserPictureForm
 from socialhome.users.models import User, Profile
 from socialhome.users.tables import FollowedTable
@@ -67,7 +68,7 @@ class ProfileDetailView(ProfileViewMixin):
         context = super().get_context_data(**kwargs)
         context["content_list"] = self.content_list
         context["pinned_content_exists"] = True
-        context["stream_name"] = "profile__%s" % self.object.id
+        context["stream_name"] = "%s__%s" % (StreamType.PROFILE_PINNED.value, self.object.id)
         context["profile_stream_type"] = "pinned"
         return context
 
@@ -84,7 +85,7 @@ class ProfileAllContentView(ProfileViewMixin):
             context["pinned_content_exists"] = qs.filter(pinned=True).exists()
         else:
             context["pinned_content_exists"] = False
-        context["stream_name"] = "profile_all__%s" % self.object.id
+        context["stream_name"] = "%s__%s" % (StreamType.PROFILE_ALL.value, self.object.id)
         context["profile_stream_type"] = "all_content"
         return context
 

--- a/socialhome/utils.py
+++ b/socialhome/utils.py
@@ -1,7 +1,14 @@
+import redis
 from django.conf import settings
 
 
 def get_full_media_url(path):
     return "{url}{media}{path}".format(
         url=settings.SOCIALHOME_URL, media=settings.MEDIA_URL, path=path,
+    )
+
+
+def get_redis_connection():
+    return redis.StrictRedis(
+        host=settings.REDIS_HOST, port=settings.REDIS_PORT, db=settings.REDIS_DB, password=settings.REDIS_PASSWORD,
     )


### PR DESCRIPTION
These support pre-caching of content ID's. No visible changes to user experience except a faster "Followed users" stream.

A stream class that is set as cached will store into Redis a list of content ID's for each user who would normally see that content in the stream. This allows pulling content out of the database very fast. If the stream is not cached or does not have cached content ID's, normal database lookups will be used.

This refactoring enables creating more complex streams which require heavier calculations to decide whether a content item should be in a stream or not.