### PR TITLE
Don't add reply content ID's to streams.js view

### DIFF
--- a/socialhome/static/js/streams.js
+++ b/socialhome/static/js/streams.js
@@ -197,8 +197,11 @@ $(function () {
                     controller.initProfileBoxTriggers();
                     window.SocialhomeContacts.addFollowUnfollowTriggers();
                 });
-                view.contentIds = _.union(view.contentIds, ids);
-                view.contentThroughIds = _.union(view.contentThroughIds, throughs);
+                if (data.placement !== "children") {
+                    // If content is not replies, update known content ID's
+                    view.contentIds = _.union(view.contentIds, ids);
+                    view.contentThroughIds = _.union(view.contentThroughIds, throughs);
+                }
             }
         },
 


### PR DESCRIPTION
The content ID's are used to decide where to continue with load more. While reply content ID's should be larger than the current stream content ID's, it is possible a few content items could get missed by the load more since we were previously also erronously counting replies too.