### PR TITLE
Logging configuration changes

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -2,6 +2,7 @@
 """
 Local settings for development environments
 """
+import os
 import sys
 
 from .common import *  # noqa

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,17 @@
 Changelog
 =========
 
+[unreleased]
+------------
+
+Changed
+.......
+
+* Logging configuration changes:
+
+  * Removed separate logfile for the federation loggers. Now all logs go to one place. Setting ``SOCIALHOME_LOGFILE_FEDERATION`` has been removed.
+  * Added possibility to direct Django and application logs using a defined level to syslog. Adds two settings, ``SOCIALHOME_LOG_TARGET`` to define whether to log to file or syslog and ``SOCIALHOME_SYSLOG_LEVEL`` to define the level of syslog logging. See `configuration <https://socialhome.readthedocs.io/en/latest/running.html#configuration>`_ documentation.
+
 0.5.0 (2017-10-01)
 ------------------
 

--- a/docs/installation/ubuntu.rst
+++ b/docs/installation/ubuntu.rst
@@ -281,7 +281,6 @@ You must change or add the following values:
     SOCIALHOME_DOMAIN=yourdomain.tld
     SOCIALHOME_HTTPS=True
     SOCIALHOME_LOGFILE=/home/socialhome/logs/socialhome.log
-    SOCIALHOME_LOGFILE_FEDERATION=/home/socialhome/logs/socialhome-federation.log
 
 For further configuration tips, see :ref:`running`.
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -217,19 +217,22 @@ Default: ``True``
 
 Force HTTPS. There should be no reason to turn this off.
 
+SOCIALHOME_LOG_TARGET
+.....................
+
+Default: ``file``
+
+Define target for Django and application logs. Possible options:
+
+* ``file``, logs will go to a file defined in ``SOCIALHOME_LOGFILE``. Note, due to multiple processes logging to the same file, this file log is only really useful for tailing or if running different processes on separate containers or machines.
+* ``syslog``, logs to syslog, to the ``local7`` facility.
+
 SOCIALHOME_LOGFILE
 ..................
 
 Default: ``/tmp/socialhome.log``
 
 Where to write the main application log.
-
-SOCIALHOME_LOGFILE_FEDERATION
-.............................
-
-Default: ``/tmp/socialhome-federation.log``
-
-Where to write the federation layer log.
 
 SOCIALHOME_RELAY_DOMAIN
 .......................
@@ -253,3 +256,10 @@ SOCIALHOME_STATISTICS
 Default: ``False``
 
 Controls whether to expose some generic statistics about the node. This includes local user, content and reply counts. User counts include 30 day and 6 month active users.
+
+SOCIALHOME_SYSLOG_LEVEL
+.......................
+
+Default: ``INFO``
+
+Define the logging level of syslog logging, if ``SOCIALHOME_LOG_TARGET`` is set to ``syslog``. Possible options: ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``.


### PR DESCRIPTION
* Removed separate logfile for the federation loggers. Now all logs go to one place. Setting ``SOCIALHOME_LOGFILE_FEDERATION`` has been removed.
* Added possibility to direct Django and application logs using a defined level to syslog. Adds two settings, ``SOCIALHOME_LOG_TARGET`` to define whether to log to file or syslog and ``SOCIALHOME_SYSLOG_LEVEL`` to define the level of syslog logging. See `configuration <https://socialhome.readthedocs.io/en/latest/running.html#configuration>`_ documentation.