### PR TITLE
Improvements to OpenGraph preview fetching

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,11 @@ Changed
   * Removed separate logfile for the federation loggers. Now all logs go to one place. Setting ``SOCIALHOME_LOGFILE_FEDERATION`` has been removed.
   * Added possibility to direct Django and application logs using a defined level to syslog. Adds two settings, ``SOCIALHOME_LOG_TARGET`` to define whether to log to file or syslog and ``SOCIALHOME_SYSLOG_LEVEL`` to define the level of syslog logging. See `configuration <https://socialhome.readthedocs.io/en/latest/running.html#configuration>`_ documentation.
 
+Fixed
+.....
+
+* Fix various issues with OpenGraph tags parsing by switching to self-maintained fork of ``python-opengraph``.
+
 0.5.0 (2017-10-01)
 ------------------
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -21,7 +21,7 @@ django-test-plus==1.0.18
 django==1.10.8
 docutils==0.14            # via sphinx
 factory-boy==2.9.2
-faker==0.8.4              # via factory-boy
+faker==0.8.4
 flake8==3.4.1
 freezegun==0.3.9
 future==0.16.0            # via commonmark

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -34,7 +34,7 @@ opbeat
 Pillow
 psycopg2
 pyembed
-python-opengraph
+python-opengraph-jaywink
 pytz
 redis
 rq

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -76,7 +76,7 @@ parso==0.1.0              # via jedi
 persisting_theory==0.2.1  # via django-dynamic-preferences
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
-pillow==4.0.0             # via django-versatileimagefield
+pillow==4.0.0
 prompt-toolkit==1.0.15    # via ipython
 psutil==5.3.1             # via circus
 psycopg2==2.7.3.1
@@ -85,14 +85,14 @@ pycrypto==2.6.1
 pyembed==1.3.3
 pygments==2.2.0           # via ipython
 python-dateutil==2.6.1    # via arrow
-python-opengraph==0.0.2
+python-opengraph-jaywink==0.1.0
 python-xrd==0.1
 python3-openid==3.1.0     # via django-allauth
 pytz==2017.2
 pyzmq==16.0.2             # via circus
 redis==2.10.6
 requests-oauthlib==0.8.0  # via django-allauth
-requests==2.18.4          # via coreapi, django-allauth, pyembed, python-opengraph, requests-oauthlib
+requests==2.18.4          # via coreapi, django-allauth, pyembed, python-opengraph-jaywink, requests-oauthlib
 rq==0.8.2
 simplegeneric==0.8.1      # via ipython
 simplejson==3.11.1        # via django-rest-swagger

--- a/socialhome/content/previews.py
+++ b/socialhome/content/previews.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import re
 
-import requests
 from django.db import DataError
 from django.db import IntegrityError
 from django.db import transaction
@@ -43,11 +42,9 @@ def fetch_og_preview(content, urls):
             opengraph = OpenGraphCache.objects.get(url=url)
             Content.objects.filter(id=content.id).update(opengraph=opengraph)
             return opengraph
-        # OpenGraph is kinda broken - make sure we destroy any old data before fetching
-        OpenGraph.__data__ = {}
         try:
-            og = OpenGraph(url=url)
-        except (requests.exceptions.ConnectionError, AttributeError):
+            og = OpenGraph(url=url, parser="lxml")
+        except AttributeError:
             continue
         if not og or ("title" not in og and "site_name" not in og and "description" not in og and "image" not in og):
             continue

--- a/socialhome/content/tests/test_previews.py
+++ b/socialhome/content/tests/test_previews.py
@@ -1,10 +1,8 @@
 import datetime
 from unittest.mock import patch
 
-import requests
 from django.db import DataError
 from freezegun import freeze_time
-from opengraph import OpenGraph
 from pyembed.core import PyEmbedError
 from pyembed.core.consumer import PyEmbedConsumerError
 from pyembed.core.discovery import PyEmbedDiscoveryError
@@ -45,23 +43,12 @@ class TestFetchOgPreview(SocialhomeTestCase):
         with freeze_time(datetime.date.today() - datetime.timedelta(days=8)):
             OpenGraphCacheFactory(url=self.urls[0])
         fetch_og_preview(self.content, self.urls)
-        og.assert_called_once_with(url=self.urls[0])
-
-    @patch("socialhome.content.previews.OpenGraph._parse")
-    def test_opengraph_data_cleared_before_fetching(self, og_parse):
-        OpenGraph.__data__ = {"foo": "bar"}
-        fetch_og_preview(self.content, self.urls)
-        self.assertEqual(OpenGraph.__data__, {})
+        og.assert_called_once_with(url=self.urls[0], parser="lxml")
 
     @patch("socialhome.content.previews.OpenGraph")
     def test_opengraph_fetch_called(self, og):
         fetch_og_preview(self.content, self.urls)
-        og.assert_called_once_with(url=self.urls[0])
-
-    @patch("socialhome.content.previews.OpenGraph", side_effect=requests.exceptions.ConnectionError)
-    def test_opengraph_connection_error_is_passed(self, og):
-        result = fetch_og_preview(self.content, self.urls)
-        self.assertFalse(result)
+        og.assert_called_once_with(url=self.urls[0], parser="lxml")
 
     @patch("socialhome.content.previews.OpenGraph")
     def test_opengraph_ignored_if_not_enough_attributes(self, og):


### PR DESCRIPTION
Use new own fork of python-opengraph.

* Timeout is defaulted to 10s
* Get exceptions are contained in the library
* No data leaking from class attributes
* Use lxml parser (less warnings in our log)