### PR TITLE
Add NSFW shield

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,6 +27,10 @@ Changed
 
   This is a more standard file name for environment variables than the previous ``env.local``. For now we'll still load from the old file too, but a warning will be displayed to rename the file.
 
+* **Breaking change**
+
+  Content API now returns Content list of tags as *name of tag*, not ID as before. The name does not contain the character "#".
+
 Fixed
 .....
 

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -1,6 +1,6 @@
 from enumfields.drf import EnumField
 from rest_framework.fields import SerializerMethodField
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, SlugRelatedField
 
 from socialhome.content.enums import ContentType
 from socialhome.content.models import Content
@@ -14,6 +14,7 @@ class ContentSerializer(ModelSerializer):
     user_following_author = SerializerMethodField()
     user_is_author = SerializerMethodField()
     user_has_shared = SerializerMethodField()
+    tags = SlugRelatedField(many=True, read_only=True, slug_field="name")
     through = SerializerMethodField()
     visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
 
@@ -26,6 +27,7 @@ class ContentSerializer(ModelSerializer):
             "guid",
             "humanized_timestamp",
             "id",
+            "is_nsfw",
             "local",
             "order",
             "parent",
@@ -52,6 +54,7 @@ class ContentSerializer(ModelSerializer):
             "guid",
             "humanized_timestamp",
             "id",
+            "is_nsfw",
             "local",
             "parent",
             "remote_created",

--- a/socialhome/content/tests/test_serializers.py
+++ b/socialhome/content/tests/test_serializers.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 from django.contrib.auth.models import AnonymousUser
 
 from socialhome.content.serializers import ContentSerializer
-from socialhome.content.tests.factories import PublicContentFactory
+from socialhome.content.tests.factories import PublicContentFactory, TagFactory
 from socialhome.tests.utils import SocialhomeTestCase
 
 
@@ -89,3 +89,15 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         self.content.share(self.profile)
         serializer = ContentSerializer(context={"request": Mock(user=self.user)})
         self.assertTrue(serializer.get_user_has_shared(self.content))
+
+    def test_tags_if_no_tag(self):
+        self.content.tags.clear()
+        serializer = ContentSerializer(self.content, context={"request": Mock(user=self.user)})
+        self.assertEquals(serializer.data["tags"], [])
+
+    def test_tags_with_tag(self):
+        tag = TagFactory(name="yolo")
+        self.content.tags.clear()
+        self.content.tags.add(tag)
+        serializer = ContentSerializer(self.content, context={"request": Mock(user=self.user)})
+        self.assertEquals(serializer.data["tags"], ["yolo"])

--- a/socialhome/streams/app/components/AuthorBar.vue
+++ b/socialhome/streams/app/components/AuthorBar.vue
@@ -62,7 +62,6 @@ export default Vue.component("author-bar", {
     },
     computed: {
         author() {
-            console.log(this.$store.state.contents[this.contentId].user_is_author)
             return this.$store.state.contents[this.contentId].author
         },
         canFollow() {

--- a/socialhome/streams/app/components/NsfwShield.vue
+++ b/socialhome/streams/app/components/NsfwShield.vue
@@ -1,0 +1,52 @@
+<template>
+    <div>
+        <b-button
+            v-if="!showNsfwContent"
+            @click.stop.prevent="toggleNsfwShield"
+            class="text-center nsfw-shield card card-block"
+            href="#"
+            variant="link"
+        >
+            {{ nsfwBtnText }}
+        </b-button>
+        <div v-else class="text-center nsfw-shield">
+            <a @click.stop.prevent="toggleNsfwShield" href="#">{{ nsfwBtnText }}</a>
+        </div>
+        <div v-show="!showNsfwContent">
+            <b-button v-for="tag in tags" :href="getTagUrl(tag)" variant="link">#{{tag}}</b-button>
+        </div>
+        <slot v-if="showNsfwContent" />
+    </div>
+</template>
+
+<script>
+import Vue from "vue"
+
+
+export default Vue.component("nsfw-shield", {
+    props: {
+        tags: {type: Array, required: true},
+    },
+    data() {
+        return {
+            showNsfwContent: false,
+        }
+    },
+    computed: {
+        nsfwBtnText() {
+            return this.showNsfwContent ? `[${gettext("Hide NSFW content")}]` : `[${gettext("Show NSFW content")}]`
+        },
+    },
+    methods: {
+        toggleNsfwShield() {
+            this.showNsfwContent = !this.showNsfwContent
+        },
+        getTagUrl(name) {
+            return Urls["streams:tag"]({name})
+        },
+    },
+    updated() {
+        Vue.redrawVueMasonry()
+    },
+})
+</script>

--- a/socialhome/streams/app/components/StreamElement.vue
+++ b/socialhome/streams/app/components/StreamElement.vue
@@ -1,6 +1,10 @@
 <template>
     <div>
-        <div v-html="content.rendered"></div>
+        <nsfw-shield v-if="content.is_nsfw" :tags="content.tags">
+            <div v-html="content.rendered" />
+        </nsfw-shield>
+        <div v-else v-html="content.rendered" />
+
         <author-bar v-if="showAuthorBar" :content-id="contentId" />
         <reactions-bar :content-id="contentId">
             <div class="mt-1">
@@ -26,6 +30,7 @@
 import Vue from "vue"
 import "streams/app/components/AuthorBar.vue"
 import "streams/app/components/ReactionsBar.vue"
+import "streams/app/components/NsfwShield.vue"
 import store from "streams/app/stores/applicationStore"
 
 

--- a/socialhome/streams/app/tests/components/NsfwShield.tests.js
+++ b/socialhome/streams/app/tests/components/NsfwShield.tests.js
@@ -1,0 +1,42 @@
+import {mount} from "avoriaz"
+
+import Vue from "vue"
+import VueMasonryPlugin from "vue-masonry"
+
+import NsfwShield from "streams/app/components/NsfwShield.vue"
+
+
+Vue.use(VueMasonryPlugin)
+
+describe("NsfwShield", () => {
+    beforeEach(() => {
+        Sinon.restore()
+    })
+
+    describe("methods", () => {
+        describe("toggleNsfwShield", () => {
+            it("should toggle `showNsfwContent`", () => {
+                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}})
+                target.instance().showNsfwContent.should.be.false
+                target.instance().toggleNsfwShield()
+                target.instance().showNsfwContent.should.be.true
+                target.instance().toggleNsfwShield()
+                target.instance().showNsfwContent.should.be.false
+            })
+
+            it("should show and hide content", (done) => {
+                let target = mount(NsfwShield, {
+                    propsData: {tags: ["nsfw"]},
+                    slots: {"default": {template: "<div>This is #NSFW content</div>"}},
+                })
+
+                target.text().should.not.match(/This is #NSFW content/)
+                target.instance().toggleNsfwShield()
+                target.instance().$nextTick(() => {
+                    target.text().should.match(/This is #NSFW content/)
+                    done()
+                })
+            })
+        })
+    })
+})


### PR DESCRIPTION
Ok, here is my proposition for a NSFW shield:

- hidden

![screenshot-2017-10-17 - socialhome](https://user-images.githubusercontent.com/22097904/31661593-934e3836-b33b-11e7-92c1-19caf554f7c2.png)
- shown

![screenshot-2017-10-17 - socialhome 1](https://user-images.githubusercontent.com/22097904/31661754-1fa1cc26-b33c-11e7-9092-cdf5eeee477e.png)

When hidden, it only shows the tags. BTW, for an unknown reason, the tags `field` of the API does not gives the correct tags. In this example, it's an array containing `3`.

The current implementation solves #111 as the HTML element is not even redered until the user clicks the button to show.