### PR TITLE
The file to place configuration environment variables has changed to ``.env``.

### DIFF
--- a/config/asgi.py
+++ b/config/asgi.py
@@ -2,8 +2,5 @@ import os
 
 from channels.asgi import get_channel_layer
 
-from config.utils import load_local_environment
-
-load_local_environment()
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
 channel_layer = get_channel_layer()

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 from datetime import datetime
 
 import environ
+import os
+import warnings
 
 ROOT_DIR = environ.Path(__file__) - 3  # (/a/b/myfile.py - 3 = /)
 APPS_DIR = ROOT_DIR.path("socialhome")
@@ -18,7 +20,15 @@ APPS_DIR = ROOT_DIR.path("socialhome")
 # Local environment
 # -----------------
 env = environ.Env()
-env.read_env("env.local")
+
+if os.path.isfile(".env"):
+    env.read_env(".env")
+else:
+    if os.path.isfile("env.local"):
+        warnings.warn("!!! 'env.local' file has been replaced by '.env'. Please rename the file!")
+        env.read_env("env.local")
+    else:
+        warnings.warn("!!! No .env file found!")
 
 # APP CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/config/utils.py
+++ b/config/utils.py
@@ -1,9 +1,0 @@
-import os
-
-def load_local_environment():
-    """Load local env variables from the env.local file."""
-    with open("env.local") as envfile:
-        for line in envfile:
-            if line.strip():
-                setting = line.strip().split("=", maxsplit=1)
-                os.environ.setdefault(setting[0], setting[1])

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -2,8 +2,5 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from config.utils import load_local_environment
-
-load_local_environment()
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
 application = get_wsgi_application()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,10 @@ Changed
   * Removed separate logfile for the federation loggers. Now all logs go to one place. Setting ``SOCIALHOME_LOGFILE_FEDERATION`` has been removed.
   * Added possibility to direct Django and application logs using a defined level to syslog. Adds three settings, ``SOCIALHOME_LOG_TARGET`` to define whether to log to file or syslog, ``SOCIALHOME_SYSLOG_LEVEL`` to define the level of syslog logging and ``SOCIALHOME_SYSLOG_FACILITY`` to define the syslog logging facility. See `configuration <https://socialhome.readthedocs.io/en/latest/running.html#configuration>`_ documentation.
 
+* **Important!** The file to place configuration environment variables has changed to ``.env``.
+
+  This is a more standard file name for environment variables than the previous ``env.local``. For now we'll still load from the old file too, but a warning will be displayed to rename the file.
+
 Fixed
 .....
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -63,11 +63,11 @@ To watch files and build bundles automatically, use this.
 Configure
 .........
 
-Configuration is done via environment variables. For the meaning of them, look them up under files in ``config/settings``. Values in ``env.local`` will be used automatically.
+Configuration is done via environment variables. For the meaning of them, look them up under files in ``config/settings``. Values in the file ``.env`` will be used automatically.
 
 ::
 
-    cp env.example env.local
+    cp .env.example .env
 
 Edit any values necessary. By default the ``SECRET_KEY`` is empty. You MUST set something to it. We don't supply a default to force you to make it unique in your production app.
 

--- a/docs/installation/ubuntu.rst
+++ b/docs/installation/ubuntu.rst
@@ -263,7 +263,7 @@ Install Python dependencies
 Create configuration
 ''''''''''''''''''''
 
-Create the file ``env.local`` with the following contents, replacing values as needed.
+Create the file ``.env`` with the following contents, replacing values as needed.
 
 You must change or add the following values:
 
@@ -288,7 +288,7 @@ Make the env file a bit less readable.
 
 ::
 
-    chmod 0600 env.local
+    chmod 0600 .env
 
 Configure email sending
 '''''''''''''''''''''''

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -54,7 +54,7 @@ Backups
 Three places should be backed up from the Socialhome instance to ensure recovery in the event of a disaster.
 
 * The database
-* Local settings in ``env.local`` (assuming you are using this way to configure the application)
+* Local settings in ``.env`` (assuming you are using this way to configure the application)
 * The path ``socialhome/media/`` which contains for example image uploads
 
 Give your instance some visibility
@@ -70,7 +70,7 @@ Why not also contribute to the numbers of the federated social web? Turn on :ref
 Configuration
 -------------
 
-Configuration mainly happens through environment variables. Those are passed to Django via the file ``env.local`` in the repository root. The following items of note can be changed.
+Configuration mainly happens through environment variables. Those are passed to Django via the file ``.env`` in the repository root. The following items of note can be changed.
 
 After making changes to this file, don't forget to reload the app with ``sudo service socialhome restart``.
 


### PR DESCRIPTION
This is a more standard file name for environment variables than the previous ``env.local``. For now we'll still load from the old file too, but a warning will be displayed to rename the file.

Also remove some left-over loading of env variables in wsgi and asgi files. It all happens in Django config now.