### PR TITLE
Fetch unknown remote share targets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Added
 
 * API ``Content`` serialization now includes an ``is_nsfw`` boolean. This is ``true`` if the content text has the tag ``#nsfw`` in it.
 
+* If an incoming share references a remote target that doesn't yet exist locally, it and the author profile will be fetched and imported over the network. (`#206 <https://github.com/jaywink/socialhome/issues/206>`_)
+
 Changed
 .......
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -39,7 +39,7 @@ parso==0.1.0              # via jedi
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
-port_for==0.3.1           # via sphinx-autobuild
+port-for==0.3.1           # via sphinx-autobuild
 prompt-toolkit==1.0.15    # via ipython
 ptyprocess==0.5.2         # via pexpect
 py==1.4.34                # via pytest

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -48,4 +48,4 @@ whoosh
 # - GIF upload
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
 
--e git+https://github.com/jaywink/federation.git@bcc779e006bc0af192db08a1ff8ed245c0fbd7c9#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@a65b04096914ac8a329dbc0e1b992872e67485fd#egg=federation==0.14.1.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements/requirements.txt requirements/requirements.in
 #
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jaywink/federation.git@bcc779e006bc0af192db08a1ff8ed245c0fbd7c9#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@a65b04096914ac8a329dbc0e1b992872e67485fd#egg=federation==0.14.1.1
 arrow==0.10.0
 asgi-redis==1.4.3
 asgiref==1.1.2            # via asgi-redis, channels, daphne
@@ -73,7 +73,7 @@ olefile==0.44             # via pillow
 opbeat==3.5.2
 openapi-codec==1.3.2      # via django-rest-swagger
 parso==0.1.0              # via jedi
-persisting_theory==0.2.1  # via django-dynamic-preferences
+persisting-theory==0.2.1  # via django-dynamic-preferences
 pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pillow==4.0.0


### PR DESCRIPTION
If an incoming share references a remote target that doesn't yet exist locally, it and the author profile will be fetched and imported over the network.

Refs: #206