### PR TITLE
Fix regression on visibility of remote replies on shares

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,11 @@ Fixed
 
   When adding replies of shares to the collection of replies fetched when clicking the reply icon in the UI, a serious performance regression was also added. Database queries have now been optimized to fetch replies faster again.
 * When editing a reply, the user is now redirected back to the parent content detail view instead of going to the reply detail view. (`#315 <https://github.com/jaywink/socialhome/issues/315>`_)
+* Fix regression on visibility of remote replies on shares.
+
+  Replies inherit the parent object visibility and share visibility defaults to non-public in the federation library. Diaspora protocol removed the ``public`` property from shares in a recent release, which meant that we started getting all shares as non-public from the federation layer. This meant that all comments on the shares were processed as non-public too.
+
+  With a change in the federation layer, Diaspora protocol shares are now public by default.
 
 0.5.0 (2017-10-01)
 ------------------

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -48,4 +48,4 @@ whoosh
 # - GIF upload
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
 
--e git+https://github.com/jaywink/federation.git@a65b04096914ac8a329dbc0e1b992872e67485fd#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@d0a816d7ff4ded46472e42a3f369e009d4f93978#egg=federation==0.14.1.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file requirements/requirements.txt requirements/requirements.in
 #
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jaywink/federation.git@a65b04096914ac8a329dbc0e1b992872e67485fd#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@d0a816d7ff4ded46472e42a3f369e009d4f93978#egg=federation==0.14.1.1
 arrow==0.10.0
 asgi-redis==1.4.3
 asgiref==1.1.2            # via asgi-redis, channels, daphne


### PR DESCRIPTION
Replies inherit the parent object visibility and share visibility defaults to non-public in the federation library. Diaspora protocol removed the ``public`` property from shares in a recent release, which meant that we started getting all shares as non-public from the federation layer. This meant that all comments on the shares were processed as non-public too.

With a change in the federation layer, Diaspora protocol shares are now public by default.