### PR TITLE
Stop extra relayable deliveries to the relay

### DIFF
--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -185,10 +185,7 @@ def forward_relayable(entity, parent_id):
     if settings.DEBUG:
         # Don't send in development mode
         return
-    recipients = [
-        (settings.SOCIALHOME_RELAY_DOMAIN, "diaspora"),
-    ]
-    recipients.extend(_get_remote_participants_for_parent(parent, exclude=entity.handle))
+    recipients = _get_remote_participants_for_parent(parent, exclude=entity.handle)
     recipients.extend(_get_remote_followers(parent.author, exclude=entity.handle))
     handle_send(entity, content.author, recipients, parent_user=parent.author)
 

--- a/socialhome/federate/tests/test_tasks.py
+++ b/socialhome/federate/tests/test_tasks.py
@@ -196,7 +196,6 @@ class TestForwardRelayable(TestCase):
         entity = Comment(handle=self.reply.author.handle, guid=self.reply.guid)
         forward_relayable(entity, self.public_content.id)
         mock_send.assert_called_once_with(entity, self.reply.author, [
-            (settings.SOCIALHOME_RELAY_DOMAIN, "diaspora"),
             (self.remote_reply.author.handle, None),
         ], parent_user=self.public_content.author)
 


### PR DESCRIPTION
For some reason we delivered forwarded relayables also to the relay. This is a bit excessive and might have possibly caused some issues. At least there is little reason to do it.