### PR TITLE
Forward remote shares of local content

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,11 @@ Added
 
    A new configuration item ``SOCIALHOME_STREAMS_PRECACHE_SIZE`` is available to set the maximum size of precached stream items per user, per stream. This defaults to 100 items. Increasing this setting can radically increase Redis memory usage. If you have a lot of users, you might consider decreasing this setting if Redis memory usage climbs up too high.
 
+Changed
+.......
+
+* When processing a remote share of local content, deliver it also to all participants in the original shared content and also to all personal followers. (`#206 <https://github.com/jaywink/socialhome/issues/206>`_)
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/socialhome/federate/utils/tasks.py
+++ b/socialhome/federate/utils/tasks.py
@@ -157,8 +157,8 @@ def process_entity_comment(entity, profile):
         logger.info("Updated Content from comment entity: %s", content)
     if parent.local:
         # We should relay this to participants we know of
-        from socialhome.federate.tasks import forward_relayable
-        django_rq.enqueue(forward_relayable, entity, parent.id)
+        from socialhome.federate.tasks import forward_entity
+        django_rq.enqueue(forward_entity, entity, parent.id)
 
 
 def _embed_entity_images_to_post(children, text):
@@ -266,6 +266,10 @@ def process_entity_share(entity, profile):
         logger.info("Updated share: %s", content)
     # TODO: send participation to the share from the author, if local
     # We probably want that to happen even though our shares are not separate in the stream?
+    if target_content.local:
+        # We should relay this share entity to participants we know of
+        from socialhome.federate.tasks import forward_entity
+        django_rq.enqueue(forward_entity, entity, target_content.id)
 
 
 def _make_post(content):


### PR DESCRIPTION
When processing a remote share of local content, deliver it also
to all participants in the original shared content and also to all
personal followers.

Refs: #206