### PR TITLE
Switch pyembed to a custom own fork

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,6 @@ lxml
 opbeat
 Pillow
 psycopg2
-pyembed
 python-opengraph-jaywink
 pytz
 redis
@@ -45,8 +44,13 @@ whitenoise
 whoosh
 
 # Own markdownx fork for some tweaks:
-# - disable tab when ctrl down
-# - GIF upload
+# - disable tab when ctrl down (https://github.com/neutronX/django-markdownx/pull/85)
+# - GIF upload (upstream rejected)
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
 
 -e git+https://github.com/jaywink/federation.git@d0a816d7ff4ded46472e42a3f369e009d4f93978#egg=federation==0.14.1.1
+
+# Own pyembed fork for some tweaks:
+# - passing additional options (TODO make PR)
+# - requests timeout (TODO make PR)
+-e git+https://github.com/jaywink/pyembed.git@e2b8a994cc90b61e3a4a53eb60cad676307d8244#egg=pyembed==1.3.3.1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,7 @@
 #
 -e git+https://github.com/jaywink/django-markdownx.git@0f7b8c01906edd5ad590bb31f04685f859d6fab1#egg=django-markdownx==2.0.21.1
 -e git+https://github.com/jaywink/federation.git@d0a816d7ff4ded46472e42a3f369e009d4f93978#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/pyembed.git@e2b8a994cc90b61e3a4a53eb60cad676307d8244#egg=pyembed==1.3.3.1
 arrow==0.10.0
 asgi-redis==1.4.3
 asgiref==1.1.2            # via asgi-redis, channels, daphne
@@ -83,7 +84,6 @@ psutil==5.3.1             # via circus
 psycopg2==2.7.3.1
 ptyprocess==0.5.2         # via pexpect
 pycrypto==2.6.1
-pyembed==1.3.3
 pygments==2.2.0           # via ipython
 python-dateutil==2.6.1    # via arrow, croniter
 python-opengraph-jaywink==0.1.0
@@ -93,7 +93,7 @@ pytz==2017.2
 pyzmq==16.0.2             # via circus
 redis==2.10.6
 requests-oauthlib==0.8.0  # via django-allauth
-requests==2.18.4          # via coreapi, django-allauth, pyembed, python-opengraph-jaywink, requests-oauthlib
+requests==2.18.4          # via coreapi, django-allauth, python-opengraph-jaywink, requests-oauthlib
 rq-scheduler==0.7.0
 rq==0.8.2
 simplegeneric==0.8.1      # via ipython

--- a/socialhome/content/previews.py
+++ b/socialhome/content/previews.py
@@ -102,8 +102,13 @@ def fetch_oembed_preview(content, urls):
             Content.objects.filter(id=content.id).update(oembed=oembed)
             return oembed
         # Fetch oembed
+        options = {}
+        if url.startswith("https://twitter.com/"):
+            # This probably has little effect since we fetch these on the backend...
+            # But, DNT is always good to communicate if possible :)
+            options = {"dnt": "true"}
         try:
-            oembed = PyEmbed(discoverer=OEmbedDiscoverer()).embed(url)
+            oembed = PyEmbed(discoverer=OEmbedDiscoverer()).embed(url, **options)
         except (PyEmbedError, PyEmbedDiscoveryError, PyEmbedConsumerError, ValueError):
             continue
         if not oembed:

--- a/socialhome/content/tests/test_previews.py
+++ b/socialhome/content/tests/test_previews.py
@@ -146,6 +146,11 @@ class TestFetchOEmbedPreview(SocialhomeTestCase):
         cls.content = ContentFactory()
         cls.urls = ["https://example.com"]
 
+    @patch("socialhome.content.previews.PyEmbed.embed", return_value="")
+    def test_adds_dnt_flag_to_twitter_oembed(self, embed):
+        result = fetch_oembed_preview(self.content, ["https://twitter.com/foobar"])
+        embed.assert_called_once_with("https://twitter.com/foobar", dnt="true")
+
     def test_cache_not_updated_if_previous_found(self):
         OEmbedCacheFactory(url=self.urls[0])
         result = fetch_oembed_preview(self.content, self.urls)


### PR DESCRIPTION
Until changes can be upstreamed. Adds a timeout to outbound calls and
possibility to set extra flags. We set the DNT flag for Twitter oembed's,
even though it likely has no value since we do backend calls. Still nice
to communicate as it's possible to do.