### PR TITLE
Fetches new content when 'new posts' label is clicked by user

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,8 @@
   },
   "globals": {
     "Urls": true,
-    "gettext": true
+    "gettext": true,
+    "interpolate": true,
+    "ngettext": true
   }
 }

--- a/mocha/setup.js
+++ b/mocha/setup.js
@@ -39,3 +39,4 @@ const file = "socialhome/streams/app/tests/fixtures/Url"
 global.Urls = require(`../${file}`).Urls // eslint-disable-line global-require, import/no-dynamic-require
 
 global.gettext = key => key
+global.ngettext = (key1, key2, num) => (num > 1 ? key2 : key1)

--- a/mocha/setup.js
+++ b/mocha/setup.js
@@ -26,6 +26,7 @@
 }())
 
 require("chai/register-should")
+require("chai").use(require("chai-as-promised"))
 
 // Noop function to make the tests pass
 global.WebSocket = function () {} // eslint-disable-line func-names

--- a/package.json
+++ b/package.json
@@ -57,11 +57,13 @@
     "ReconnectingWebSocket": "https://github.com/joewalnes/reconnecting-websocket.git#1.0.0",
     "axios": "~0.16.2",
     "bootstrap-vue": "~1.2.0",
+    "chai-as-promised": "^7.1.1",
     "lodash": "~4.17.4",
     "vue": "~2.4.1",
     "vue-images-loaded": "1.1.2",
     "vue-infinite-scroll": "^2.0.2",
     "vue-masonry": "=0.10.3",
+    "vue-scrollto": "^2.8.0",
     "vuex": "~2.3.1",
     "vuex-rest-api": "^2.2.1"
   },

--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -30,15 +30,20 @@
 <script>
 import Vue from "vue"
 import imagesLoaded from "vue-images-loaded"
+import VueScrollTo from "vue-scrollto"
+
 import "streams/app/components/StreamElement.vue"
 import PublicStampedElement from "streams/app/components/stamped_elements/PublicStampedElement.vue"
 import FollowedStampedElement from "streams/app/components/stamped_elements/FollowedStampedElement.vue"
 import TagStampedElement from "streams/app/components/stamped_elements/TagStampedElement.vue"
 import ProfileStampedElement from "streams/app/components/stamped_elements/ProfileStampedElement.vue"
 import "streams/app/components/LoadingElement.vue"
+
 import {newStreamStore, streamStoreOperations} from "streams/app/stores/streamStore"
 import applicationStore from "streams/app/stores/applicationStore"
 
+
+Vue.use(VueScrollTo)
 
 export default Vue.component("stream", {
     store: newStreamStore({modules: {applicationStore}}),
@@ -86,7 +91,9 @@ export default Vue.component("stream", {
             Vue.redrawVueMasonry()
         },
         onNewContentClick() {
-            this.$store.dispatch(streamStoreOperations.newContentAck)
+            this.$store.dispatch(streamStoreOperations.newContentAck).then(
+                () => this.$nextTick( // Wait for new content to be rendered
+                    () => this.$scrollTo("body")))
         },
     },
     beforeCreate() {

--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
         <div class="container-flex">
-            <div v-show="$store.state.hasNewContent" class="new-content-container">
+            <div v-show="$store.getters.hasNewContent" class="new-content-container">
                 <b-link @click.prevent.stop="onNewContentClick" class="new-content-load-link">
                     <b-badge pill variant="primary">
-                        {{ $store.state.newContentLengh }} new posts available
+                        {{ translations.newPostsAvailables }}
                     </b-badge>
                 </b-link>
             </div>
@@ -70,6 +70,15 @@ export default Vue.component("stream", {
             } else {
                 console.error(`Unsupported stream name ${this.$store.state.streamName}`)
             }
+        },
+        translations() {
+            const ln = this.unfetchedContentIds.length
+            return {
+                newPostsAvailables: ngettext(`${ln} new post available`, `${ln} new posts available`, ln),
+            }
+        },
+        unfetchedContentIds() {
+            return this.$store.state.unfetchedContentIds
         },
     },
     methods: {

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -1,9 +1,12 @@
 import Vue from "vue"
+import _concat from "lodash/concat"
+import _difference from "lodash/difference"
 
 
 const streamStoreOperations = {
     disableLoadMore: "disableLoadMore",
     getFollowedStream: "getFollowedStream",
+    getNewContent: "getNewContent",
     getProfileAll: "getProfileAll",
     getProfilePinned: "getProfilePinned",
     getPublicStream: "getPublicStream",
@@ -16,24 +19,25 @@ const streamStoreOperations = {
     saveReply: "saveReply",
 }
 
-// This is the Vuex way
-/* eslint-disable no-param-reassign */
 const mutations = {
     [streamStoreOperations.disableLoadMore](state, contentId) {
         Vue.set(state.contents[contentId], "hasLoadMore", false)
     },
     [streamStoreOperations.receivedNewContent](state, contentId) {
-        state.hasNewContent = true
-        state.newContentLengh += 1
-        state.contentIds.unshift(contentId)
-        Vue.set(state.contents, contentId, undefined)
+        state.unfetchedContentIds.push(contentId)
     },
     [streamStoreOperations.newContentAck](state) {
-        state.hasNewContent = false
-        state.newContentLengh = 0
+        /*
+         * First, get all IDs present in unfetchedContentIds and absent in contentIds
+         * This is neccessary since content ids that could not be fetched due to
+         * network errors are not removed from `state.unfetchedContentIds`. In this
+         * case, the next time unfetched content is fetched, these ids would be added
+         * twice and appear twice in the stream.
+         */
+        const diff = _difference(state.unfetchedContentIds, state.contentIds)
+        Vue.set(state, "contentIds", _concat(diff, state.contentIds))
     },
 }
-/* eslint-enable no-param-reassign */
 
 const actions = {
     [streamStoreOperations.disableLoadMore]({commit}, contentId) {
@@ -64,8 +68,11 @@ const actions = {
     [streamStoreOperations.receivedNewContent]({commit}, newContentLengh) {
         commit(streamStoreOperations.receivedNewContent, newContentLengh)
     },
-    [streamStoreOperations.newContentAck]({commit}) {
+    [streamStoreOperations.newContentAck]({commit, dispatch, state}) {
         commit(streamStoreOperations.newContentAck)
+        state.unfetchedContentIds.forEach(pk => {
+            dispatch(streamStoreOperations.getNewContent, {params: {pk}})
+        })
     },
 }
 
@@ -98,6 +105,9 @@ const getters = {
             shares.push(state.shares[id])
         })
         return shares
+    },
+    hasNewContent(state) {
+        return state.unfetchedContentIds.length > 0 && !state.pending.contents
     },
 }
 

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -70,9 +70,15 @@ const actions = {
     },
     [streamStoreOperations.newContentAck]({commit, dispatch, state}) {
         commit(streamStoreOperations.newContentAck)
+        const promises = []
+        const resolve = () => Promise.resolve()
         state.unfetchedContentIds.forEach(pk => {
-            dispatch(streamStoreOperations.getNewContent, {params: {pk}})
+            // Force the promise to resolve in all cases
+            const promise = dispatch(streamStoreOperations.getNewContent, {params: {pk}})
+                .then(resolve, resolve)
+            promises.push(promise)
         })
+        return Promise.all(promises)
     },
 }
 

--- a/socialhome/streams/app/stores/streamStore.state.js
+++ b/socialhome/streams/app/stores/streamStore.state.js
@@ -3,6 +3,7 @@ import _get from "lodash/get"
 
 export default function () {
     const contentIds = []
+    const unfetchedContentIds = []
     const contents = {}
     const replies = {}
     const shares = {}
@@ -18,5 +19,6 @@ export default function () {
         showAuthorBar: streamName.length > 0 ? !streamName.startsWith("profile_") : false,
         streamName,
         tagName: _get(window, ["context", "tagName"], ""),
+        unfetchedContentIds,
     }
 }

--- a/socialhome/streams/app/tests/components/Stream.tests.js
+++ b/socialhome/streams/app/tests/components/Stream.tests.js
@@ -82,7 +82,7 @@ describe("Stream", () => {
                 target.instance().$store.commit(streamStoreOperations.receivedNewContent, 1)
                 target.instance().$nextTick(() => {
                     target.find(".new-content-container")[0].hasStyle("display", "none").should.be.false
-                    target.find(".new-content-container .badge")[0].text().should.match(/1 new posts available/)
+                    target.find(".new-content-container .badge")[0].text().should.match(/1 new post available/)
                     done()
                 })
             })

--- a/socialhome/streams/app/tests/stores/streamStore.tests.js
+++ b/socialhome/streams/app/tests/stores/streamStore.tests.js
@@ -266,15 +266,15 @@ describe("streamStore", () => {
                     "1": {id: "1", text: "Plop"},
                     "2": {id: "2", text: "Hello!"},
                 },
-                unfetchedContentIds: ["6"]
+                unfetchedContentIds: ["6"],
             }
 
             exportsForTests.fetchNewContentSuccess(state, payload)
 
             state.contents.should.eql({
-                    "1": {id: "1", text: "Plop"},
-                    "2": {id: "2", text: "Hello!"},
-                    "6": {id: "6", text: "Yolo"},
+                "1": {id: "1", text: "Plop"},
+                "2": {id: "2", text: "Hello!"},
+                "6": {id: "6", text: "Yolo"},
             })
         })
 
@@ -286,7 +286,7 @@ describe("streamStore", () => {
                     "1": {id: "1", text: "Plop"},
                     "2": {id: "2", text: "Hello!"},
                 },
-                unfetchedContentIds: ["6"]
+                unfetchedContentIds: ["6"],
             }
 
             exportsForTests.fetchNewContentSuccess(state, payload)
@@ -621,9 +621,11 @@ describe("streamStore", () => {
                     response: {id: "6", content_type: "reply", parent: "1", text: "a cool reply"},
                 })
 
-                target.dispatch(streamStoreOperations.saveReply, {data: {
-                    contentId: 1, text: "a cool reply",
-                }})
+                target.dispatch(streamStoreOperations.saveReply, {
+                    data: {
+                        contentId: 1, text: "a cool reply",
+                    },
+                })
 
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
@@ -792,7 +794,7 @@ describe("streamStore", () => {
                     state.streamName = "followed__spameater"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
-                        [streamStoreOperations.getFollowedStream, {params: {lastId: "4"}}]
+                        [streamStoreOperations.getFollowedStream, {params: {lastId: "4"}}],
                     )
                 })
 
@@ -800,7 +802,7 @@ describe("streamStore", () => {
                     state.streamName = "public"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
-                        [streamStoreOperations.getPublicStream, {params: {lastId: "4"}}]
+                        [streamStoreOperations.getPublicStream, {params: {lastId: "4"}}],
                     )
                 })
 
@@ -809,7 +811,7 @@ describe("streamStore", () => {
                     state.tagName = "eggs"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
-                        [streamStoreOperations.getTagStream, {params: {name: "eggs", lastId: "4"}}]
+                        [streamStoreOperations.getTagStream, {params: {name: "eggs", lastId: "4"}}],
                     )
                 })
 
@@ -817,7 +819,7 @@ describe("streamStore", () => {
                     state.streamName = "profile_all__1234-5678"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
-                        [streamStoreOperations.getProfileAll, {params: {id: 5, lastId: "4"}}]
+                        [streamStoreOperations.getProfileAll, {params: {id: 5, lastId: "4"}}],
                     )
                 })
 
@@ -825,7 +827,7 @@ describe("streamStore", () => {
                     state.streamName = "profile_pinned__1234-5678"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
-                        [streamStoreOperations.getProfilePinned, {params: {id: 5, lastId: "4"}}]
+                        [streamStoreOperations.getProfilePinned, {params: {id: 5, lastId: "4"}}],
                     )
                 })
             })
@@ -851,11 +853,22 @@ describe("streamStore", () => {
             it("should dispatch 'streamStoreOperations.getNewContent' for every unfetched ID", () => {
                 let state = {unfetchedContentIds: [1, 2, 3]}
                 let commit = Sinon.spy()
-                let dispatch = Sinon.spy()
+                let dispatch = Sinon.stub().returns(new Promise(resolve => resolve()))
                 actions[streamStoreOperations.newContentAck]({commit, state, dispatch})
                 dispatch.getCall(0).args.should.eql([streamStoreOperations.getNewContent, {params: {pk: 1}}])
                 dispatch.getCall(1).args.should.eql([streamStoreOperations.getNewContent, {params: {pk: 2}}])
                 dispatch.getCall(2).args.should.eql([streamStoreOperations.getNewContent, {params: {pk: 3}}])
+            })
+
+            it("should always resolve even if one dispatch operation fails", (done) => {
+                let state = {unfetchedContentIds: [1, 2, 3]}
+                let commit = Sinon.spy()
+                let dispatch = Sinon.stub()
+                    .onCall(0).returns(Promise.resolve())
+                    .onCall(1).returns(Promise.reject("Fetch error"))
+                    .onCall(2).returns(Promise.resolve())
+
+                actions[streamStoreOperations.newContentAck]({commit, state, dispatch}).should.be.fulfilled.notify(done)
             })
         })
     })
@@ -886,7 +899,7 @@ describe("streamStore", () => {
                         "2": {id: "2"},
                         "4": {id: "4"},
                         "5": {id: "5"},
-                        "7": {id: "7"}
+                        "7": {id: "7"},
                     },
                     shares: {
                         "6": {id: "6", replyIds: ["7"]},
@@ -909,7 +922,7 @@ describe("streamStore", () => {
                         "2": {id: "2"},
                         "4": {id: "4"},
                         "5": {id: "5"},
-                        "7": {id: "7"}
+                        "7": {id: "7"},
                     },
                 }
                 getters.shares(state)(1).should.eql([{id: "2"}, {id: "4"}])


### PR DESCRIPTION
Supersedes #360

- Changed logic of 'streamStoreOperations.newContentAck' to fetch new content
- Changed logic of 'streamStoreOperations.receivedNewContent' to stack received post ids to fetch in a list
- Replaced 'streamStore.state.hasNewContent' by 'streamStore.state.unfetchedContentIds' to stack content ids to fetch
- Render new posts when they are fetched
- Jump to top of page after content was fetched
- Tests ok