### PR TITLE
Fix Twitter oembed's in Vue streams

### DIFF
--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -8,7 +8,7 @@
                     </b-badge>
                 </b-button>
             </div>
-            <div v-images-loaded.on.progress="onImageLoad" v-masonry v-bind="masonryOptions">
+            <div v-images-loaded.on.done="onImageLoad" v-masonry v-bind="masonryOptions">
                 <div class="stamped">
                     <component :is="stampedElement" />
                 </div>
@@ -85,6 +85,36 @@ export default Vue.component("stream", {
     },
     beforeDestroy() {
         this.$store.$websocket.close()
+    },
+    updated() {
+        // Fetch Twitter script and init embeds when updated.
+        // Adapted from: https://gist.github.com/fahrenq/0e815fef2bd296f2e9a061cc27e5a27b
+        (function (d, s, id, c) {
+            let js
+            let fjs = d.getElementsByTagName(s)[0]
+            if (fjs === undefined) return
+            let t = window.twttr || {}
+            if (d.getElementById(id) && t.widgets !== undefined) {
+                if (t.events._handlers === undefined || t.events._handlers.loaded.length === 0) {
+                    // Bind a tweet loaded event for images loaded, but only once
+                    t.events.bind('loaded', () => {
+                        c.onImageLoad()
+                    })
+                }
+                // Init embeds
+                return t.widgets.load();
+            }
+            // Fetch script to window
+            js = d.createElement(s)
+            js.id = id
+            js.src = "https://platform.twitter.com/widgets.js"
+            fjs.parentNode.insertBefore(js, fjs)
+            t._e = []
+            t.ready = function (f) {
+                t._e.push(f)
+              }
+            return t;
+        }(document, "script", "twitter-wjs", this))
     },
 })
 </script>


### PR DESCRIPTION
Since the provided async script in oembed's doesn't fire correctly
in Vue streams, we fetch and init the embeds in Stream component
updated method. This is a standard way to embed multiple tweets on
a page from Twitter. For Vue we need some extra tricks and some
binding to make sure imagesLoaded triggers also when the tweet embeds
have finished rendering.

Refs: #202