### PR TITLE
Vue streams quick reply in stream

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,10 @@ Changed
 
 * When processing a remote share of local content, deliver it also to all participants in the original shared content and also to all personal followers. (`#206 <https://github.com/jaywink/socialhome/issues/206>`_)
 
+* Allow creating replies via the Content API.
+
+  Replies are created by simply passing in a ``parent`` with the ID value of the target Content. It is not possible to change the ``parent`` value for an existing reply or root level Content object once created.
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -34,7 +34,7 @@ Changed
 
 * Allow creating replies via the Content API.
 
-  Replies are created by simply passing in a ``parent`` with the ID value of the target Content. It is not possible to change the ``parent`` value for an existing reply or root level Content object once created.
+  Replies are created by simply passing in a ``parent`` with the ID value of the target Content. It is not possible to change the ``parent`` value for an existing reply or root level Content object once created. When creating a reply, you can omit ``visibility`` from the sent data. Visibility will be used from the parent Content item automatically.
 
 0.6.0 (2017-11-13)
 ------------------

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "autoprefixer-core": "~6.0.1",
-    "avoriaz": "^3.2.0",
+    "avoriaz": "^6.3.0",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.1",
     "babel-preset-env": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "ReconnectingWebSocket": "https://github.com/joewalnes/reconnecting-websocket.git#1.0.0",
     "axios": "~0.16.2",
-    "bootstrap-vue": "~0.20.2",
+    "bootstrap-vue": "~1.2.0",
     "lodash": "~4.17.4",
     "vue": "~2.4.1",
     "vue-images-loaded": "1.1.2",

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -1,6 +1,6 @@
 from enumfields.drf import EnumField
+from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
-from rest_framework.serializers import ModelSerializer, SlugRelatedField
 
 from socialhome.content.enums import ContentType
 from socialhome.content.models import Content
@@ -8,13 +8,13 @@ from socialhome.enums import Visibility
 from socialhome.users.serializers import LimitedProfileSerializer
 
 
-class ContentSerializer(ModelSerializer):
+class ContentSerializer(serializers.ModelSerializer):
     author = LimitedProfileSerializer(read_only=True)
     content_type = EnumField(ContentType, ints_as_names=True, read_only=True)
     user_following_author = SerializerMethodField()
     user_is_author = SerializerMethodField()
     user_has_shared = SerializerMethodField()
-    tags = SlugRelatedField(many=True, read_only=True, slug_field="name")
+    tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
     through = SerializerMethodField()
     visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
 
@@ -57,7 +57,6 @@ class ContentSerializer(ModelSerializer):
             "id",
             "is_nsfw",
             "local",
-            "parent",
             "remote_created",
             "rendered",
             "reply_count",
@@ -71,6 +70,9 @@ class ContentSerializer(ModelSerializer):
             "user_is_author",
             "user_has_shared",
         )
+
+    # TODO validate visibility
+    # - if create and has parent -> set from parent
 
     def get_through(self, obj):
         """Through is generally required only for serializing content for streams."""
@@ -96,3 +98,10 @@ class ContentSerializer(ModelSerializer):
         if not request:
             return False
         return Content.has_shared(obj.id, request.user.profile.id) if hasattr(request.user, "profile") else False
+
+    def validate_parent(self, value):
+        """
+        Validate parent cannot be changed.
+        """
+        if self.instance and value != self.instance.parent:
+            raise serializers.ValidationError("Parent cannot be changed for an existing Content instance.")

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -108,7 +108,7 @@ class ContentSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError("Visibility was given but it doesn't match parent.")
             data["visibility"] = parent.visibility
         else:
-            if not data.get("visibility"):
+            if not self.instance and not data.get("visibility"):
                 raise serializers.ValidationError("Visibility is required")
         return data
 
@@ -117,7 +117,7 @@ class ContentSerializer(serializers.ModelSerializer):
         if self.instance and value != self.instance.parent:
             raise serializers.ValidationError("Parent cannot be changed for an existing Content instance.")
         # Validate user can see parent
-        if value:
+        if not self.instance and value:
             request = self.context.get("request")
             if not value.visible_for_user(request.user):
                 raise serializers.ValidationError("Parent not found")

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -16,7 +16,7 @@ class ContentSerializer(serializers.ModelSerializer):
     user_has_shared = SerializerMethodField()
     tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
     through = SerializerMethodField()
-    visibility = EnumField(Visibility, lenient=True, ints_as_names=True)
+    visibility = EnumField(Visibility, lenient=True, ints_as_names=True, required=False)
 
     class Meta:
         model = Content
@@ -71,9 +71,6 @@ class ContentSerializer(serializers.ModelSerializer):
             "user_has_shared",
         )
 
-    # TODO validate visibility
-    # - if create and has parent -> set from parent
-
     def get_through(self, obj):
         """Through is generally required only for serializing content for streams."""
         throughs = self.context.get("throughs")
@@ -99,9 +96,30 @@ class ContentSerializer(serializers.ModelSerializer):
             return False
         return Content.has_shared(obj.id, request.user.profile.id) if hasattr(request.user, "profile") else False
 
+    def validate(self, data):
+        """
+        Validate visibility is not required for replies.
+
+        If given, make sure it is the same as parent. If not given, use parent visibility.
+        """
+        parent = data.get("parent")
+        if parent:
+            if data.get("visibility") and parent.visibility != data.get("visibility"):
+                raise serializers.ValidationError("Visibility was given but it doesn't match parent.")
+            data["visibility"] = parent.visibility
+        else:
+            if not data.get("visibility"):
+                raise serializers.ValidationError("Visibility is required")
+        return data
+
     def validate_parent(self, value):
-        """
-        Validate parent cannot be changed.
-        """
+        # Validate parent cannot be changed
         if self.instance and value != self.instance.parent:
             raise serializers.ValidationError("Parent cannot be changed for an existing Content instance.")
+        # Validate user can see parent
+        if value:
+            request = self.context.get("request")
+            if not value.visible_for_user(request.user):
+                raise serializers.ValidationError("Parent not found")
+        return value
+

--- a/socialhome/content/tests/test_serializers.py
+++ b/socialhome/content/tests/test_serializers.py
@@ -29,16 +29,7 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         except AttributeError:
             pass
 
-    def test_create_with_parent__without(self):
-        serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
-            "text": "Without parent", "visibility": "public",
-        })
-        self.assertTrue(serializer.is_valid())
-        serializer.save(author=self.user.profile)
-        content = Content.objects.order_by("id").last()
-        self.assertEqual(content.text, "Without parent")
-
-    def test_create_with_parent__with(self):
+    def test_create_with_parent(self):
         serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
             "text": "With parent", "visibility": "public", "parent": self.content.id,
         })
@@ -54,6 +45,12 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         })
         self.assertFalse(serializer.is_valid())
 
+    def test_create_with_parent__visibility_does_not_match_parent(self):
+        serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
+            "text": "With parent visibility mismatch", "visibility": "public", "parent": self.limited_content.id,
+        })
+        self.assertFalse(serializer.is_valid())
+
     def test_create_with_visibility(self):
         serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
             "text": "With visibility", "visibility": "public",
@@ -63,6 +60,21 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         content = Content.objects.order_by("id").last()
         self.assertEqual(content.text, "With visibility")
         self.assertEqual(content.visibility, Visibility.PUBLIC)
+
+    def test_create_without_parent(self):
+        serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
+            "text": "Without parent", "visibility": "public",
+        })
+        self.assertTrue(serializer.is_valid())
+        serializer.save(author=self.user.profile)
+        content = Content.objects.order_by("id").last()
+        self.assertEqual(content.text, "Without parent")
+
+    def test_create_without_visibility(self):
+        serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={
+            "text": "Without visibility",
+        })
+        self.assertFalse(serializer.is_valid())
 
     def test_create_without_visibility__reply(self):
         serializer = ContentSerializer(context={"request": Mock(user=self.user)}, data={

--- a/socialhome/content/viewsets.py
+++ b/socialhome/content/viewsets.py
@@ -41,11 +41,14 @@ class ContentViewSet(mixins.CreateModelMixin, mixins.RetrieveModelMixin, mixins.
                      mixins.DestroyModelMixin, GenericViewSet):
     """
     create:
-        Create content
+        Create content or reply
 
-        Required values: `text` and `visibility`.
+        When creating top level content, required values are: `text` and `visibility`.
+        Value for `visibility` should be one of: `public`, `site`, `limited`, `self`.
 
-        `visibility` should be one of: `public`, `site`, `limited`, `self`.
+        When creating replies, required values are: `text` and `parent`. The `parent` value is the ID of the
+        content that is being replied on. A reply cannot have `visibility` set to anything else than the parent
+        content visibility.
 
     replies:
         Get list of replies

--- a/socialhome/streams/app/components/RepliesContainer.vue
+++ b/socialhome/streams/app/components/RepliesContainer.vue
@@ -12,7 +12,10 @@
             <i class="fa fa-spinner fa-spin fa-2x" aria-hidden="true"></i>
         </div>
         <div v-if="showReplyButton" class="content-actions">
-            <b-button :href="replyUrl" variant="secondary">{{ translations.reply }}</b-button>
+            <b-button @click.prevent.stop="showReplyEditor" variant="secondary">{{ translations.reply }}</b-button>
+        </div>
+        <div v-if="replyEditorActive">
+            <reply-editor :content-id="content.id" />
         </div>
         <div v-if="isContent">
             <div v-for="share in shares" :key="share.id">
@@ -28,12 +31,18 @@ import imagesLoaded from "vue-images-loaded"
 import Vue from "vue"
 
 import {streamStoreOperations} from "streams/app/stores/streamStore.operations";
+import "streams/app/components/ReplyEditor.vue"
 
 
 export default Vue.component("replies-container", {
     directives: {imagesLoaded},
     props: {
         content: {type: Object, required: true},
+    },
+    data() {
+        return {
+            replyEditorActive: false,
+        }
     },
     computed: {
         isContent() {
@@ -45,14 +54,12 @@ export default Vue.component("replies-container", {
         replies() {
             return this.$store.getters.replies(this.content)
         },
-        replyUrl() {
-            return Urls["content:reply"]({pk: this.content.id})
-        },
         shares() {
             return this.$store.getters.shares(this.content.id)
         },
         showReplyButton() {
-            if (!this.isUserAuthenticated || (this.$store.state.pending.replies && this.content.reply_count > 0)) {
+            if (!this.isUserAuthenticated || this.replyEditorActive || (
+                    this.$store.state.pending.replies && this.content.reply_count > 0)) {
                 return false
             }
             if (this.content.content_type === "content") {
@@ -74,6 +81,9 @@ export default Vue.component("replies-container", {
     methods: {
         onImageLoad() {
             Vue.redrawVueMasonry()
+        },
+        showReplyEditor() {
+            this.replyEditorActive = true
         },
     },
     mounted() {

--- a/socialhome/streams/app/components/ReplyEditor.vue
+++ b/socialhome/streams/app/components/ReplyEditor.vue
@@ -49,7 +49,7 @@ export default Vue.component("reply-editor", {
         saveReply() {
             this.$store.dispatch(
                 streamStoreOperations.saveReply, {
-                    data: {parent: this.contentId, text: this.replyText, visibility: "public"},
+                    data: {parent: this.contentId, text: this.replyText},
                 }
             )
             this.replyText = ""

--- a/socialhome/streams/app/components/ReplyEditor.vue
+++ b/socialhome/streams/app/components/ReplyEditor.vue
@@ -1,0 +1,71 @@
+<template>
+    <div>
+        <div class="mt-2">
+            <b-form-textarea
+                :max-rows="5"
+                :placeholder="translations.replyText"
+                :rows="5"
+                v-model="replyText"
+            ></b-form-textarea>
+        </div>
+        <div class="pull-right">
+            <a :href="fullEditorUrl" target="_blank" rel="noopener noreferrer">{{ translations.fullEditor }}</a>
+        </div>
+        <div class="reply-save-button">
+            <b-button @click.prevent.stop="saveReply" variant="primary">{{ translations.save }}</b-button>
+        </div>
+    </div>
+</template>
+
+
+<script>
+import Vue from "vue"
+
+import {streamStoreOperations} from "streams/app/stores/streamStore.operations";
+
+
+export default Vue.component("reply-editor", {
+    props: {
+        contentId: {type: Number, required: true},
+    },
+    data() {
+        return {
+            replyText: "",
+        }
+    },
+    computed: {
+        fullEditorUrl() {
+            return Urls["content:reply"]({pk: this.contentId})
+        },
+        translations() {
+            return {
+                fullEditor: gettext("Full editor"),
+                replyText: gettext("Reply text..."),
+                save: gettext("Save"),
+            }
+        },
+    },
+    methods: {
+        saveReply() {
+            this.$store.dispatch(
+                streamStoreOperations.saveReply, {
+                    data: {parent: this.contentId, text: this.replyText, visibility: "public"},
+                }
+            )
+            this.replyText = ""
+        },
+    },
+})
+</script>
+
+
+<style scoped lang="scss">
+    .reply-save-button {
+        padding-top: 10px;
+
+        a, button {
+            width: 100%;
+            cursor: pointer;
+        }
+    }
+</style>

--- a/socialhome/streams/app/components/ReplyEditor.vue
+++ b/socialhome/streams/app/components/ReplyEditor.vue
@@ -47,12 +47,14 @@ export default Vue.component("reply-editor", {
     },
     methods: {
         saveReply() {
-            this.$store.dispatch(
-                streamStoreOperations.saveReply, {
-                    data: {parent: this.contentId, text: this.replyText},
-                }
-            )
-            this.replyText = ""
+            if (this.replyText) {
+                this.$store.dispatch(
+                    streamStoreOperations.saveReply, {
+                        data: {parent: this.contentId, text: this.replyText},
+                    }
+                )
+                this.replyText = ""
+            }
         },
     },
 })

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -13,6 +13,7 @@ const streamStoreOperations = {
     loadStream: "loadStream",
     newContentAck: "newContentAck",
     receivedNewContent: "receivedNewContent",
+    saveReply: "saveReply",
 }
 
 // This is the Vuex way

--- a/socialhome/streams/app/tests/components/RepliesContainer.tests.js
+++ b/socialhome/streams/app/tests/components/RepliesContainer.tests.js
@@ -46,11 +46,6 @@ describe("RepliesContainer", () => {
             target.instance().replies.should.eql([store.reply])
         })
 
-        it("replyUrl", () => {
-            let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
-            target.instance().replyUrl.should.eql(`/content/${store.content.id}/~reply/`)
-        })
-
         it("shares", () => {
             let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
             target.instance().shares.should.eql([store.share])

--- a/socialhome/streams/app/tests/components/RepliesContainer.tests.js
+++ b/socialhome/streams/app/tests/components/RepliesContainer.tests.js
@@ -7,6 +7,7 @@ import {getFakeContent} from "streams/app/tests/fixtures/jsonContext.fixtures"
 import {getStore} from "streams/app/tests/fixtures/store.fixtures"
 import {streamStoreOperations} from "streams/app/stores/streamStore.operations"
 import RepliesContainer from "streams/app/components/RepliesContainer.vue"
+import StreamElement from "streams/app/components/StreamElement.vue"
 
 Vue.use(BootstrapVue)
 Vue.use(VueMasonryPlugin)
@@ -51,21 +52,36 @@ describe("RepliesContainer", () => {
             target.instance().shares.should.eql([store.share])
         })
 
-        it("showReplyButton", () => {
-            let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
-            target.instance().showReplyButton.should.be.true
+        context("showReplyButton", () => {
+            it("shows reply button on root content", () => {
+                let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
+                target.instance().showReplyButton.should.be.true
+            })
 
-            store.share2 = getFakeContent({share_of: store.content.id, content_type: "share", reply_count: 0})
-            Vue.set(store.state.shares, store.share2.id, store.share2)
-            target = mount(RepliesContainer, {propsData: {content: store.share2}, store})
-            target.instance().showReplyButton.should.be.false
+            it("does not show reply button for a share without replies", () => {
+                store.share2 = getFakeContent({share_of: store.content.id, content_type: "share", reply_count: 0})
+                Vue.set(store.state.shares, store.share2.id, store.share2)
+                let target = mount(RepliesContainer, {propsData: {content: store.share2}, store})
+                target.instance().showReplyButton.should.be.false
+            })
 
-            store.share2.reply_count = 1
-            target = mount(RepliesContainer, {propsData: {content: store.share2}, store})
-            target.instance().showReplyButton.should.be.true
+            it("shows reply button for a share with replies", () => {
+                store.share3 = getFakeContent({share_of: store.content.id, content_type: "share", reply_count: 1})
+                Vue.set(store.state.shares, store.share3.id, store.share3)
+                let target = mount(RepliesContainer, {propsData: {content: store.share3}, store})
+                target.instance().showReplyButton.should.be.true
+            })
 
-            target = mount(RepliesContainer, {propsData: {content: store.reply}, store})
-            target.instance().showReplyButton.should.be.false
+            it("does not show reply button for a reply", () => {
+                let target = mount(RepliesContainer, {propsData: {content: store.reply}, store})
+                target.instance().showReplyButton.should.be.false
+            })
+
+            it("does not show reply button if reply editor is active", () => {
+                let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
+                target.instance().showReplyEditor()
+                target.instance().showReplyButton.should.be.false
+            })
         })
     })
 
@@ -76,6 +92,15 @@ describe("RepliesContainer", () => {
                 Sinon.spy(Vue, "redrawVueMasonry")
                 target.instance().onImageLoad()
                 Vue.redrawVueMasonry.called.should.be.true
+            })
+        })
+
+        describe("showReplyEditor", () => {
+            it("toggles replyEditorActive", () => {
+                let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
+                target.instance().replyEditorActive.should.be.false
+                target.instance().showReplyEditor()
+                target.instance().replyEditorActive.should.be.true
             })
         })
     })

--- a/socialhome/streams/app/tests/components/ReplyEditor.tests.js
+++ b/socialhome/streams/app/tests/components/ReplyEditor.tests.js
@@ -1,0 +1,68 @@
+import {mount} from "avoriaz"
+import Vue from "vue"
+import BootstrapVue from "bootstrap-vue"
+import VueMasonryPlugin from "vue-masonry"
+
+import {getStore} from "streams/app/tests/fixtures/store.fixtures"
+import {streamStoreOperations} from "streams/app/stores/streamStore.operations"
+import ReplyEditor from "streams/app/components/ReplyEditor.vue"
+
+Vue.use(BootstrapVue)
+Vue.use(VueMasonryPlugin)
+
+
+describe("ReplyEditor", () => {
+    let store
+
+    beforeEach(() => {
+        store = getStore()
+        Sinon.stub(store, "dispatch")
+    })
+
+    afterEach(() => {
+        Sinon.restore()
+    })
+
+    describe("computed", () => {
+        it("fullEditorUrl", () => {
+            let target = mount(ReplyEditor, {propsData: {contentId: store.content.id}, store})
+            target.instance().fullEditorUrl.should.eql(`/content/${store.content.id}/~reply/`)
+        })
+    })
+
+    describe("methods", () => {
+        context("saveReply", () => {
+            it("dispatches saveReply", () => {
+                let target = mount(ReplyEditor, {propsData: {contentId: store.content.id}, store})
+                target.setData({replyText: "\"Code without tests doesn't exist\" -Albert Einstein"})
+                target.instance().saveReply()
+                store.dispatch.callCount.should.eql(1)
+                store.dispatch.args[0].should.eql([
+                    streamStoreOperations.saveReply, {
+                        data: {parent: store.content.id, text: "\"Code without tests doesn't exist\" -Albert Einstein"}
+                    },
+                ])
+                target.data().replyText.should.eql("")
+            })
+
+            it("does not dispatch saveReply if replyText is empty ", () => {
+                let target = mount(ReplyEditor, {propsData: {contentId: store.content.id}, store})
+                target.setData({replyText: ""})
+                target.instance().saveReply()
+                store.dispatch.callCount.should.eql(0)
+            })
+        })
+    })
+
+    describe("template", () => {
+        it("has a save button", () => {
+            let target = mount(ReplyEditor, {propsData: {contentId: store.content.id}, store})
+            target.find("button").length.should.eql(1)
+        })
+
+        it("has a text area", () => {
+            let target = mount(ReplyEditor, {propsData: {contentId: store.content.id}, store})
+            target.find("textarea").length.should.eql(1)
+        })
+    })
+})


### PR DESCRIPTION
* Add quick reply editor to grid replies container

  On clicking reply, don't open the full editor, instead show a quick
  reply box under the current replies. Save button adds the reply to the
  current replies.
  
  Provide a link to the full editor also since it has preview and image uploads.

* Bump bootstrap-vue to latest version.
* Make Content API parent writable

  Required to create replies via the API.

![peek 2017-11-26 22-01](https://user-images.githubusercontent.com/1174866/33243812-806880e4-d2f5-11e7-9562-cc19626855f9.gif)

TODO:
- [x] Fix tests
- [x] Add tests for new functionality
- [x] Add missing validation logic to Content API parent/visibility as per todo's in serializer
- [x] Add changelog entry for Content API change
- [x] Remove hard coded visibility from vue side post once API doesn't require it for replies
- [x] Ensure everything works nicely for replies on shares
- [x] Add notes to API docs

Refs: #202
