### PR TITLE
Fix Vue streams NSFW shield

### DIFF
--- a/socialhome/streams/app/components/NsfwShield.vue
+++ b/socialhome/streams/app/components/NsfwShield.vue
@@ -1,29 +1,30 @@
 <template>
-    <div>
-        <b-button
+    <div v-images-loaded.on.progress="onImageLoad">
+        <b-link
             v-if="!showNsfwContent"
             @click.stop.prevent="toggleNsfwShield"
             class="text-center nsfw-shield card card-block"
             href="#"
-            variant="link"
         >
             {{ nsfwBtnText }}
-        </b-button>
+        </b-link>
         <div v-else class="text-center nsfw-shield">
             <a @click.stop.prevent="toggleNsfwShield" href="#">{{ nsfwBtnText }}</a>
         </div>
-        <div v-show="!showNsfwContent">
-            <b-button v-for="tag in tags" :key="tag" :href="getTagUrl(tag)" variant="link">#{{tag}}</b-button>
+        <div v-show="!showNsfwContent" class="mt-2 mb-2">
+            <b-link v-for="tag in tags" :key="tag" :href="getTagUrl(tag)" class="mr-2">#{{ tag }}</b-link>
         </div>
         <slot v-if="showNsfwContent" />
     </div>
 </template>
 
 <script>
+import imagesLoaded from "vue-images-loaded"
 import Vue from "vue"
 
 
 export default Vue.component("nsfw-shield", {
+    directives: {imagesLoaded},
     props: {
         tags: {type: Array, required: true},
     },
@@ -38,6 +39,9 @@ export default Vue.component("nsfw-shield", {
         },
     },
     methods: {
+        onImageLoad() {
+            Vue.redrawVueMasonry()
+        },
         toggleNsfwShield() {
             this.showNsfwContent = !this.showNsfwContent
         },

--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -2,11 +2,11 @@
     <div>
         <div class="container-flex">
             <div v-show="$store.state.hasNewContent" class="new-content-container">
-                <b-button @click.prenvent.stop="onNewContentClick" variant="link" class="new-content-load-link">
+                <b-link @click.prevent.stop="onNewContentClick" class="new-content-load-link">
                     <b-badge pill variant="primary">
                         {{ $store.state.newContentLengh }} new posts available
                     </b-badge>
-                </b-button>
+                </b-link>
             </div>
             <div v-images-loaded.on.done="onImageLoad" v-masonry v-bind="masonryOptions">
                 <div class="stamped">

--- a/socialhome/streams/app/tests/components/NsfwShield.tests.js
+++ b/socialhome/streams/app/tests/components/NsfwShield.tests.js
@@ -1,12 +1,14 @@
 import {mount} from "avoriaz"
 
 import Vue from "vue"
+import BootstrapVue from "bootstrap-vue"
 import VueMasonryPlugin from "vue-masonry"
 
 import NsfwShield from "streams/app/components/NsfwShield.vue"
 
-
+Vue.use(BootstrapVue)
 Vue.use(VueMasonryPlugin)
+
 
 describe("NsfwShield", () => {
     beforeEach(() => {
@@ -14,6 +16,15 @@ describe("NsfwShield", () => {
     })
 
     describe("methods", () => {
+        describe("onImageLoad", () => {
+            it("should call Vue.redrawVueMasonry", () => {
+                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.instance().onImageLoad()
+                Vue.redrawVueMasonry.called.should.be.true
+            })
+        })
+
         describe("toggleNsfwShield", () => {
             it("should toggle `showNsfwContent`", () => {
                 let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}})

--- a/socialhome/streams/templates/streams/vue.html
+++ b/socialhome/streams/templates/streams/vue.html
@@ -16,3 +16,15 @@
     <script type="text/javascript" charset="utf-8">{% js_reverse_inline %}</script>
     <script src="{% static 'js/webpack.stream.js' %}"></script>
 {% endblock %}
+
+
+{% block css %}
+    {{ block.super }}
+    {# TODO: remove this override once legacy streams are removed #}
+    {# Also change Content render to not add .nsfw class at all. #}
+    <style>
+        .nsfw {
+            display: unset;
+        }
+    </style>
+{% endblock %}


### PR DESCRIPTION
Vue-bootstrap update changed behaviour of b-button component which doesn't
work as a link any more. Now it's b-link. Also images did not show after
removing shield due to old styling. Override the display style in the Vue
template for now.

Refs: #202