### PR TITLE
Add Vue single content view

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
 include = socialhome/*
-omit = *migrations*, *tests*, *scripts*
+omit = *migrations*, *tests*, *scripts*, *commands*
 plugins =
     django_coverage_plugin

--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
   ],
   "rules": {
     "arrow-parens": ["error", "as-needed"],
-    "indent": ["error", 4],
+    "indent": ["error", 4, {"SwitchCase": 1}],
     "import/extensions": "off",
     "import/no-extraneous-dependencies": "off",
     "import/no-unresolved": "off",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node-sass": "^4.5.3",
     "pixrem": "~3.0.2",
     "sass-loader": "^6.0.6",
-    "sinon": "^3.2.0",
+    "sinon": "^4.1.2",
     "style-loader": "^0.18.2",
     "time-grunt": "~1.4.0",
     "vue-loader": "~12.2.2",

--- a/socialhome/content/management/__init__.py
+++ b/socialhome/content/management/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/socialhome/content/management/commands/__init__.py
+++ b/socialhome/content/management/commands/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals

--- a/socialhome/content/management/commands/create_dummy_content.py
+++ b/socialhome/content/management/commands/create_dummy_content.py
@@ -1,0 +1,16 @@
+from django.core.management.base import BaseCommand
+
+from socialhome.content.tests.factories import PublicContentFactory
+
+
+class Command(BaseCommand):
+    help = "Create dummy content."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--amount", type=int, help="Amount to create, defaults to 100.", default=100)
+
+    def handle(self, *args, **options):
+        """Create dummy content."""
+        for i in range(options["amount"]):
+            content = PublicContentFactory()
+            print("Created content: %s" % content)

--- a/socialhome/content/tests/factories.py
+++ b/socialhome/content/tests/factories.py
@@ -1,9 +1,8 @@
 import factory
-from factory import fuzzy
 
 from socialhome.content.models import Content, OEmbedCache, OpenGraphCache, Tag
 from socialhome.enums import Visibility
-from socialhome.users.tests.factories import ProfileFactory, UserFactory
+from socialhome.users.tests.factories import ProfileFactory, UserFactory, PublicProfileFactory
 
 
 class TagFactory(factory.DjangoModelFactory):
@@ -17,28 +16,25 @@ class ContentFactory(factory.DjangoModelFactory):
     class Meta:
         model = Content
 
-    text = fuzzy.FuzzyText()
-    guid = fuzzy.FuzzyText()
+    text = factory.Faker("text")
+    guid = factory.Faker("uuid4")
     author = factory.SubFactory(ProfileFactory)
 
 
 class PublicContentFactory(ContentFactory):
-    text = fuzzy.FuzzyText(prefix="Public ")
     visibility = Visibility.PUBLIC
+    author = factory.SubFactory(PublicProfileFactory)
 
 
 class LimitedContentFactory(ContentFactory):
-    text = fuzzy.FuzzyText(prefix="Limited ")
     visibility = Visibility.LIMITED
 
 
 class SiteContentFactory(ContentFactory):
-    text = fuzzy.FuzzyText(prefix="Site ")
     visibility = Visibility.SITE
 
 
 class SelfContentFactory(ContentFactory):
-    text = fuzzy.FuzzyText(prefix="Self ")
     visibility = Visibility.SELF
 
 

--- a/socialhome/content/tests/test_querysets.py
+++ b/socialhome/content/tests/test_querysets.py
@@ -5,14 +5,14 @@ from socialhome.content.tests.factories import (
     PublicContentFactory, LimitedContentFactory, SelfContentFactory, SiteContentFactory)
 from socialhome.enums import Visibility
 from socialhome.tests.utils import SocialhomeTestCase
-from socialhome.users.tests.factories import UserFactory, PublicUserFactory
+from socialhome.users.tests.factories import UserFactory, PublicUserFactory, ProfileFactory
 
 
 class TestContentQuerySet(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
-        cls.public_content = PublicContentFactory(pinned=True)
+        cls.public_content = PublicContentFactory(pinned=True, author=ProfileFactory())
         cls.public_tag_content = PublicContentFactory(text="#foobar")
         cls.limited_content = LimitedContentFactory()
         cls.tag = Tag.objects.get(name="foobar")

--- a/socialhome/streams/app/components/NsfwShield.vue
+++ b/socialhome/streams/app/components/NsfwShield.vue
@@ -40,7 +40,9 @@ export default Vue.component("nsfw-shield", {
     },
     methods: {
         onImageLoad() {
-            Vue.redrawVueMasonry()
+            if (!this.$store.state.stream.single) {
+                Vue.redrawVueMasonry()
+            }
         },
         toggleNsfwShield() {
             this.showNsfwContent = !this.showNsfwContent
@@ -50,7 +52,9 @@ export default Vue.component("nsfw-shield", {
         },
     },
     updated() {
-        Vue.redrawVueMasonry()
+        if (!this.$store.state.stream.single) {
+            Vue.redrawVueMasonry()
+        }
     },
 })
 </script>

--- a/socialhome/streams/app/components/ReactionsBar.vue
+++ b/socialhome/streams/app/components/ReactionsBar.vue
@@ -34,7 +34,7 @@
             </b-button>
             <b-button v-else variant="secondary" @click.prevent.stop="share">{{ translations.share }}</b-button>
         </div>
-        <div v-if="showRepliesBox || $store.state.stream.single">
+        <div v-if="showRepliesContainer">
             <replies-container :content="content" />
         </div>
     </div>
@@ -59,6 +59,9 @@ export default Vue.component("reactions-bar", {
     computed: {
         showReplies() {
             return this.$store.state.applicationStore.isUserAuthenticated || this.content.reply_count > 0
+        },
+        showRepliesContainer() {
+            return this.showRepliesBox || this.$store.state.stream.single
         },
         showShares() {
             return this.$store.state.applicationStore.isUserAuthenticated || this.content.shares_count > 0

--- a/socialhome/streams/app/components/ReactionsBar.vue
+++ b/socialhome/streams/app/components/ReactionsBar.vue
@@ -34,7 +34,7 @@
             </b-button>
             <b-button v-else variant="secondary" @click.prevent.stop="share">{{ translations.share }}</b-button>
         </div>
-        <div v-if="showRepliesBox">
+        <div v-if="showRepliesBox || $store.state.stream.single">
             <replies-container :content="content" />
         </div>
     </div>
@@ -116,7 +116,9 @@ export default Vue.component("reactions-bar", {
         },
     },
     updated() {
-        Vue.redrawVueMasonry()
+        if (!this.$store.state.stream.single) {
+            Vue.redrawVueMasonry()
+        }
     },
 })
 </script>

--- a/socialhome/streams/app/components/RepliesContainer.vue
+++ b/socialhome/streams/app/components/RepliesContainer.vue
@@ -80,7 +80,9 @@ export default Vue.component("replies-container", {
     },
     methods: {
         onImageLoad() {
-            Vue.redrawVueMasonry()
+            if (!this.$store.state.stream.single) {
+                Vue.redrawVueMasonry()
+            }
         },
         showReplyEditor() {
             this.replyEditorActive = true
@@ -93,7 +95,9 @@ export default Vue.component("replies-container", {
         }
     },
     updated() {
-        Vue.redrawVueMasonry()
+        if (!this.$store.state.stream.single) {
+            Vue.redrawVueMasonry()
+        }
     },
 })
 </script>

--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -1,35 +1,41 @@
 <template>
-    <div>
-        <div class="container-flex">
-            <div v-show="$store.getters.hasNewContent" class="new-content-container">
-                <b-link @click.prevent.stop="onNewContentClick" class="new-content-load-link">
-                    <b-badge pill variant="primary">
-                        {{ translations.newPostsAvailables }}
-                    </b-badge>
-                </b-link>
-            </div>
-            <div v-images-loaded.on.progress="onImageLoad" v-masonry v-bind="masonryOptions">
-                <div class="stamped">
-                    <component :is="stampedElement" />
-                </div>
-                <div class="grid-sizer"></div>
-                <div class="gutter-sizer"></div>
-                <stream-element
-                    class="grid-item"
-                    v-masonry-tile
-                    v-for="content in $store.getters.contentList"
-                    :content="content"
-                    :key="content.id"
-                />
-            </div>
-            <loading-element v-show="$store.state.pending.contents" />
+    <div :class="{ container: this.$store.state.stream.single }">
+        <div v-show="$store.getters.hasNewContent" class="new-content-container">
+            <b-link @click.prevent.stop="onNewContentClick" class="new-content-load-link">
+                <b-badge pill variant="primary">
+                    {{ translations.newPostsAvailables }}
+                </b-badge>
+            </b-link>
         </div>
+        <div v-if="this.$store.state.stream.single">
+            <stream-element
+                class="grid-item grid-item-full"
+                :content="$store.state.content"
+                :key="$store.state.content.id"
+            />
+        </div>
+        <div v-else v-masonry v-bind="masonryOptions">
+            <div class="stamped">
+                <component :is="stampedElement" />
+            </div>
+            <div class="grid-sizer"></div>
+            <div class="gutter-sizer"></div>
+            <stream-element
+                class="grid-item"
+                v-masonry-tile
+                v-for="content in $store.getters.contentList"
+                :content="content"
+                :key="content.id"
+            />
+        </div>
+        <loading-element v-show="$store.state.pending.contents" />
     </div>
 </template>
 
+
 <script>
 import Vue from "vue"
-import imagesLoaded from "vue-images-loaded"
+
 import VueScrollTo from "vue-scrollto"
 
 import "streams/app/components/StreamElement.vue"
@@ -47,7 +53,6 @@ Vue.use(VueScrollTo)
 
 export default Vue.component("stream", {
     store: newStreamStore({modules: {applicationStore}}),
-    directives: {imagesLoaded},
     components: {FollowedStampedElement, PublicStampedElement, ProfileStampedElement, TagStampedElement},
     data() {
         return {
@@ -64,16 +69,18 @@ export default Vue.component("stream", {
     },
     computed: {
         stampedElement() {
-            if (this.$store.state.streamName.match(/^followed/)) {
-                return "FollowedStampedElement"
-            } else if (this.$store.state.streamName.match(/^public/)) {
-                return "PublicStampedElement"
-            } else if (this.$store.state.streamName.match(/^tag/)) {
-                return "TagStampedElement"
-            } else if (this.$store.state.streamName.match(/^profile/)) {
-                return "ProfileStampedElement"
-            } else {
-                console.error(`Unsupported stream name ${this.$store.state.streamName}`)
+            switch (this.$store.state.stream.name) {
+                case "followed":
+                    return "FollowedStampedElement"
+                case "public":
+                    return "PublicStampedElement"
+                case "tag":
+                    return "TagStampedElement"
+                case "profile_all":
+                case "profile_pinned":
+                    return "ProfileStampedElement"
+                default:
+                    console.error(`Unsupported stream name ${this.$store.state.stream.name}`)
             }
         },
         translations() {
@@ -87,9 +94,6 @@ export default Vue.component("stream", {
         },
     },
     methods: {
-        onImageLoad() {
-            Vue.redrawVueMasonry()
-        },
         onNewContentClick() {
             this.$store.dispatch(streamStoreOperations.newContentAck).then(
                 () => this.$nextTick( // Wait for new content to be rendered
@@ -97,45 +101,26 @@ export default Vue.component("stream", {
         },
     },
     beforeCreate() {
-        this.$store.dispatch(streamStoreOperations.loadStream)
+        if (!this.$store.state.stream.single) {
+            this.$store.dispatch(streamStoreOperations.loadStream)
+        }
     },
     beforeDestroy() {
         this.$store.$websocket.close()
     },
-    updated() {
-        // Fetch Twitter script and init embeds when updated.
-        // Adapted from: https://gist.github.com/fahrenq/0e815fef2bd296f2e9a061cc27e5a27b
-        (function (d, s, id, c) {
-            let js
-            let fjs = d.getElementsByTagName(s)[0]
-            if (fjs === undefined) return
-            let t = window.twttr || {}
-            if (d.getElementById(id) && t.widgets !== undefined) {
-                if (t.events._handlers === undefined || t.events._handlers.loaded.length === 0) {
-                    // Bind a tweet loaded event for images loaded, but only once
-                    t.events.bind('loaded', () => {
-                        c.onImageLoad()
-                    })
-                }
-                // Init embeds
-                return t.widgets.load();
-            }
-            // Fetch script to window
-            js = d.createElement(s)
-            js.id = id
-            js.src = "https://platform.twitter.com/widgets.js"
-            fjs.parentNode.insertBefore(js, fjs)
-            t._e = []
-            t.ready = function (f) {
-                t._e.push(f)
-              }
-            return t;
-        }(document, "script", "twitter-wjs", this))
-    },
 })
 </script>
 
+
 <style scoped lang="scss">
+    @media all and (max-width: 1200px) {
+        .container {
+            width: 100%;
+            max-width: unset;
+            padding-left: 0;
+            padding-right: 0;
+        }
+    }
     .new-content-load-link {
         cursor: pointer;
     }

--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -10,8 +10,7 @@
         <div v-if="this.$store.state.stream.single">
             <stream-element
                 class="grid-item grid-item-full"
-                :content="$store.state.content"
-                :key="$store.state.content.id"
+                :content="$store.getters.singleContent"
             />
         </div>
         <div v-else v-masonry v-bind="masonryOptions">

--- a/socialhome/streams/app/components/StreamElement.vue
+++ b/socialhome/streams/app/components/StreamElement.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div v-images-loaded.on.progress="onImageLoad" >
         <div v-if="content.hasLoadMore">
             <div v-infinite-scroll="loadMore" infinite-scroll-disabled="disableLoadMore"></div>
         </div>
@@ -32,6 +32,7 @@
 
 <script>
 import Vue from "vue"
+import imagesLoaded from "vue-images-loaded"
 
 import {streamStoreOperations} from "streams/app/stores/streamStore.operations"
 import "streams/app/components/AuthorBar.vue"
@@ -40,6 +41,7 @@ import "streams/app/components/NsfwShield.vue"
 
 
 export default Vue.component("stream-element", {
+    directives: {imagesLoaded},
     props: {
         content: {type: Object, required: true},
     },
@@ -71,13 +73,54 @@ export default Vue.component("stream-element", {
         },
     },
     methods: {
+        initTwitterOEmbed() {
+            // Fetch Twitter script and init embed when updated.
+            // Adapted from: https://gist.github.com/fahrenq/0e815fef2bd296f2e9a061cc27e5a27b
+            (function (d, s, id, c) {
+                let js
+                let fjs = d.getElementsByTagName(s)[0]
+                if (fjs === undefined) return
+                let t = window.twttr || {}
+                if (d.getElementById(id) && t.widgets !== undefined) {
+                    if (t.events._handlers === undefined || t.events._handlers.loaded.length === 0) {
+                        // Bind a tweet loaded event for images loaded, but only once
+                        t.events.bind('loaded', () => {
+                            c.onImageLoad()
+                        })
+                    }
+                    // Init embeds
+                    return t.widgets.load();
+                }
+                // Fetch script to window
+                js = d.createElement(s)
+                js.id = id
+                js.src = "https://platform.twitter.com/widgets.js"
+                if (d.getElementById(id)) return  // Try not to load JS more than once
+                fjs.parentNode.insertBefore(js, fjs)
+                t._e = []
+                t.ready = function (f) {
+                    t._e.push(f)
+                  }
+                return t;
+            }(document, "script", "twitter-wjs", this))
+        },
         loadMore() {
             this.$store.dispatch(streamStoreOperations.disableLoadMore, this.content.id)
             this.$store.dispatch(streamStoreOperations.loadStream)
         },
+        onImageLoad() {
+            if (!this.$store.state.stream.single) {
+                Vue.redrawVueMasonry()
+            }
+        },
+    },
+    mounted() {
+        this.initTwitterOEmbed()
     },
     updated() {
-        Vue.redrawVueMasonry()
+        if (!this.$store.state.stream.single) {
+            Vue.redrawVueMasonry()
+        }
     },
 })
 </script>

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -120,6 +120,12 @@ const getters = {
         })
         return shares
     },
+    singleContent(state) {
+        if (!state.singleContentId) {
+            return null
+        }
+        return state.contents[state.singleContentId]
+    },
     hasNewContent(state) {
         return state.unfetchedContentIds.length > 0 && !state.pending.contents
     },

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -50,19 +50,27 @@ const actions = {
             options.params.lastId = state.contents[lastContentId].through
         }
 
-        if (state.streamName.match(/^followed/)) {
-            dispatch(streamStoreOperations.getFollowedStream, options)
-        } else if (state.streamName.match(/^public/)) {
-            dispatch(streamStoreOperations.getPublicStream, options)
-        } else if (state.streamName.match(/^tag/)) {
-            options.params.name = state.tagName
-            dispatch(streamStoreOperations.getTagStream, options)
-        } else if (state.streamName.match(/^profile_all/)) {
-            options.params.id = state.applicationStore.profile.id
-            dispatch(streamStoreOperations.getProfileAll, options)
-        } else if (state.streamName.match(/^profile_pinned/)) {
-            options.params.id = state.applicationStore.profile.id
-            dispatch(streamStoreOperations.getProfilePinned, options)
+        switch (state.stream.name) {
+            case "followed":
+                dispatch(streamStoreOperations.getFollowedStream, options)
+                break
+            case "public":
+                dispatch(streamStoreOperations.getPublicStream, options)
+                break
+            case "tag":
+                options.params.name = state.tagName
+                dispatch(streamStoreOperations.getTagStream, options)
+                break
+            case "profile_all":
+                options.params.id = state.applicationStore.profile.id
+                dispatch(streamStoreOperations.getProfileAll, options)
+                break
+            case "profile_pinned":
+                options.params.id = state.applicationStore.profile.id
+                dispatch(streamStoreOperations.getProfilePinned, options)
+                break
+            default:
+                console.log(`Unknown stream name ${state.stream.name}`)
         }
     },
     [streamStoreOperations.receivedNewContent]({commit}, newContentLengh) {

--- a/socialhome/streams/app/stores/streamStore.state.js
+++ b/socialhome/streams/app/stores/streamStore.state.js
@@ -2,21 +2,37 @@ import _get from "lodash/get"
 
 
 export default function () {
+    const content = _get(window, ["context", "content"], undefined)
     const contentIds = []
     const unfetchedContentIds = []
     const contents = {}
+    if (content) {
+        content.replyIds = []
+        content.shareIds = []
+        contentIds.push(content.id)
+        contents[content.id] = content
+    }
     const replies = {}
     const shares = {}
     const streamName = _get(window, ["context", "streamName"], "")
+    const streamSplits = streamName.split("__")
+    const stream = {
+        id: streamSplits.length ? streamSplits[1] : "",
+        isProfile: streamName.startsWith("profile_"),
+        name: streamSplits[0],
+        single: streamSplits[0] === "content",
+    }
 
     return {
+        content,
         contents,
         contentIds,
         hasNewContent: false,
         newContentLengh: 0,
         replies,
         shares,
-        showAuthorBar: streamName.length > 0 ? !streamName.startsWith("profile_") : false,
+        showAuthorBar: !stream.isProfile,
+        stream,
         streamName,
         tagName: _get(window, ["context", "tagName"], ""),
         unfetchedContentIds,

--- a/socialhome/streams/app/stores/streamStore.state.js
+++ b/socialhome/streams/app/stores/streamStore.state.js
@@ -2,18 +2,23 @@ import _get from "lodash/get"
 
 
 export default function () {
-    const content = _get(window, ["context", "content"], undefined)
     const contentIds = []
     const unfetchedContentIds = []
     const contents = {}
+    const replies = {}
+    const shares = {}
+
+    // Handle single content if exists
+    const content = _get(window, ["context", "content"], undefined)
+    let singleContentId = null
     if (content) {
+        singleContentId = content.id
         content.replyIds = []
         content.shareIds = []
         contentIds.push(content.id)
         contents[content.id] = content
     }
-    const replies = {}
-    const shares = {}
+
     const streamName = _get(window, ["context", "streamName"], "")
     const streamSplits = streamName.split("__")
     const stream = {
@@ -24,7 +29,6 @@ export default function () {
     }
 
     return {
-        content,
         contents,
         contentIds,
         hasNewContent: false,
@@ -32,6 +36,7 @@ export default function () {
         replies,
         shares,
         showAuthorBar: !stream.isProfile,
+        singleContentId,
         stream,
         streamName,
         tagName: _get(window, ["context", "tagName"], ""),

--- a/socialhome/streams/app/tests/components/AuthorBar.tests.js
+++ b/socialhome/streams/app/tests/components/AuthorBar.tests.js
@@ -129,7 +129,7 @@ describe("AuthorBar", () => {
                 target.find(".profilebox-trigger")[0].trigger("click")
                 target.instance().profileBoxTrigger.calledOnce.should.be.true
                 target.instance().showProfileBox.should.be.true
-                target.find(".profile-box")[0].hasAttribute("display", "none").should.be.false
+                target.find(".profile-box")[0].hasAttribute("display").should.be.false
             })
         })
 

--- a/socialhome/streams/app/tests/components/NsfwShield.tests.js
+++ b/socialhome/streams/app/tests/components/NsfwShield.tests.js
@@ -19,13 +19,48 @@ describe("NsfwShield", () => {
         store = getStore()
     })
 
-    describe("methods", () => {
-        describe("onImageLoad", () => {
-            it("should call Vue.redrawVueMasonry", () => {
+    describe("lifecycle", () => {
+        context("updated", () => {
+            it("redraws masonry if not single stream", (done) => {
                 let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
                 Sinon.spy(Vue, "redrawVueMasonry")
-                target.instance().onImageLoad()
-                Vue.redrawVueMasonry.called.should.be.true
+                target.update()
+                target.vm.$nextTick(() => {
+                    Vue.redrawVueMasonry.called.should.be.true
+                    done()
+                })
+            })
+
+            it("does not redraw masonry if single stream", (done) => {
+                store.state.stream.single = true
+                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.update()
+                target.vm.$nextTick(() => {
+                    Vue.redrawVueMasonry.called.should.be.false
+                    done()
+                })
+            })
+        })
+    })
+
+    describe("methods", () => {
+        describe("onImageLoad", () => {
+            context("call Vue.redrawVueMasonry", () => {
+                it("does if not single stream", () => {
+                    let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
+                    Sinon.spy(Vue, "redrawVueMasonry")
+                    target.instance().onImageLoad()
+                    Vue.redrawVueMasonry.called.should.be.true
+                })
+
+                it("does not if single stream", () => {
+                    store.state.stream.single = true
+                    let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
+                    Sinon.spy(Vue, "redrawVueMasonry")
+                    target.instance().onImageLoad()
+                    Vue.redrawVueMasonry.called.should.be.false
+                })
             })
         })
 

--- a/socialhome/streams/app/tests/components/NsfwShield.tests.js
+++ b/socialhome/streams/app/tests/components/NsfwShield.tests.js
@@ -5,20 +5,24 @@ import BootstrapVue from "bootstrap-vue"
 import VueMasonryPlugin from "vue-masonry"
 
 import NsfwShield from "streams/app/components/NsfwShield.vue"
+import {getStore} from "streams/app/tests/fixtures/store.fixtures"
 
 Vue.use(BootstrapVue)
 Vue.use(VueMasonryPlugin)
 
 
 describe("NsfwShield", () => {
+    let store
+
     beforeEach(() => {
         Sinon.restore()
+        store = getStore()
     })
 
     describe("methods", () => {
         describe("onImageLoad", () => {
             it("should call Vue.redrawVueMasonry", () => {
-                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}})
+                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
                 Sinon.spy(Vue, "redrawVueMasonry")
                 target.instance().onImageLoad()
                 Vue.redrawVueMasonry.called.should.be.true
@@ -27,7 +31,7 @@ describe("NsfwShield", () => {
 
         describe("toggleNsfwShield", () => {
             it("should toggle `showNsfwContent`", () => {
-                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}})
+                let target = mount(NsfwShield, {propsData: {tags: ["nsfw"]}, store})
                 target.instance().showNsfwContent.should.be.false
                 target.instance().toggleNsfwShield()
                 target.instance().showNsfwContent.should.be.true
@@ -39,6 +43,7 @@ describe("NsfwShield", () => {
                 let target = mount(NsfwShield, {
                     propsData: {tags: ["nsfw"]},
                     slots: {"default": {template: "<div>This is #NSFW content</div>"}},
+                    store,
                 })
 
                 target.text().should.not.match(/This is #NSFW content/)

--- a/socialhome/streams/app/tests/components/ReactionsBar.tests.js
+++ b/socialhome/streams/app/tests/components/ReactionsBar.tests.js
@@ -15,7 +15,7 @@ import applicationStore from "streams/app/stores/applicationStore"
 Vue.use(BootstrapVue)
 Vue.use(VueMasonryPlugin)
 
-describe("ReactionBar", () => {
+describe("ReactionsBar", () => {
     let content
     let store
 
@@ -70,6 +70,31 @@ describe("ReactionBar", () => {
                 target.instance().$store.state.contents[1].shares_count = 0
                 target.instance().$store.state.applicationStore.isUserAuthenticated = false
                 target.instance().showShares.should.be.false
+            })
+        })
+    })
+
+    describe("lifecycle", () => {
+        context("updated", () => {
+            it("redraws masonry if not single stream", (done) => {
+                let target = mount(ReactionsBar, {propsData: {content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.update()
+                target.vm.$nextTick(() => {
+                    Vue.redrawVueMasonry.called.should.be.true
+                    done()
+                })
+            })
+
+            it("does not redraw masonry if single stream", (done) => {
+                store.state.stream.single = true
+                let target = mount(ReactionsBar, {propsData: {content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.update()
+                target.vm.$nextTick(() => {
+                    Vue.redrawVueMasonry.called.should.be.false
+                    done()
+                })
             })
         })
     })

--- a/socialhome/streams/app/tests/components/RepliesContainer.tests.js
+++ b/socialhome/streams/app/tests/components/RepliesContainer.tests.js
@@ -87,11 +87,19 @@ describe("RepliesContainer", () => {
 
     describe("methods", () => {
         describe("onImageLoad", () => {
-            it("should call Vue.redrawVueMasonry", () => {
+            it("should call Vue.redrawVueMasonry if not single stream", () => {
                 let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
                 Sinon.spy(Vue, "redrawVueMasonry")
                 target.instance().onImageLoad()
                 Vue.redrawVueMasonry.called.should.be.true
+            })
+
+            it("should not call Vue.redrawVueMasonry if single stream", () => {
+                store.state.stream.single = true
+                let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.instance().onImageLoad()
+                Vue.redrawVueMasonry.called.should.be.false
             })
         })
 
@@ -142,12 +150,23 @@ describe("RepliesContainer", () => {
     })
 
     describe("updated", () => {
-        it("redraws masonry", done => {
+        it("redraws masonry if not single stream", done => {
             let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
             Sinon.spy(Vue, "redrawVueMasonry")
             target.update()
             target.instance().$nextTick(() => {
             Vue.redrawVueMasonry.called.should.be.true
+                done()
+            })
+        })
+
+        it("does not redraw masonry if single stream", done => {
+            store.state.stream.single = true
+            let target = mount(RepliesContainer, {propsData: {content: store.content}, store})
+            Sinon.spy(Vue, "redrawVueMasonry")
+            target.update()
+            target.instance().$nextTick(() => {
+            Vue.redrawVueMasonry.called.should.be.false
                 done()
             })
         })

--- a/socialhome/streams/app/tests/components/Stream.tests.js
+++ b/socialhome/streams/app/tests/components/Stream.tests.js
@@ -7,58 +7,54 @@ import VueMasonryPlugin from "vue-masonry"
 import Stream from "streams/app/components/Stream.vue"
 import PublicStampedElement from "streams/app/components/stamped_elements/PublicStampedElement.vue"
 import FollowedStampedElement from "streams/app/components/stamped_elements/FollowedStampedElement.vue"
-import {streamStoreOperations, newStreamStore} from "streams/app/stores/streamStore"
-import applicationStore from "streams/app/stores/applicationStore"
+import {streamStoreOperations} from "streams/app/stores/streamStore"
+import {getStore} from "streams/app/tests/fixtures/store.fixtures"
 
 
 Vue.use(BootstrapVue)
 Vue.use(VueMasonryPlugin)
 
 describe("Stream", () => {
+    let store
+
     beforeEach(() => {
         Sinon.restore()
+        store = getStore()
     })
 
     describe("computed", () => {
         describe("stampedElement", () => {
             it("should render the FollowedStampedElement when stream name is 'followed'", () => {
-                let store = newStreamStore({modules: {applicationStore}})
-                store.state.applicationStore.profile = {id: 26}
+                store.state.stream.name = "followed"
                 let target = mount(Stream, {store})
-                target.instance().$store.state.streamName = "followed"
                 target.instance().stampedElement.should.eq("FollowedStampedElement")
             })
 
             it("should render the PublicStampedElement when stream name is 'public'", () => {
-                let store = newStreamStore({modules: {applicationStore}})
-                store.state.applicationStore.profile = {id: 26}
+                store.state.stream.name = "public"
                 let target = mount(Stream, {store})
-                target.instance().$store.state.streamName = "public"
                 target.instance().stampedElement.should.eq("PublicStampedElement")
             })
 
             it("should render the TagStampedElement when stream name is 'tag'", () => {
-                let store = newStreamStore({modules: {applicationStore}})
-                store.state.applicationStore.profile = {id: 26}
+                store.state.stream.name = "tag"
                 let target = mount(Stream, {store})
-                target.instance().$store.state.streamName = "tag"
                 target.instance().stampedElement.should.eq("TagStampedElement")
             })
 
             it("should render the ProfileStampedElement when stream name is 'profile'", () => {
-                let store = newStreamStore({modules: {applicationStore}})
-                store.state.applicationStore.profile = {id: 26}
+                store.state.stream.name = "profile_all"
                 let target = mount(Stream, {store})
-                target.instance().$store.state.streamName = "profile"
+                target.instance().stampedElement.should.eq("ProfileStampedElement")
+                store.state.stream.name = "profile_pinned"
+                target = mount(Stream, {store})
                 target.instance().stampedElement.should.eq("ProfileStampedElement")
             })
 
             it("should display an error when stream name is unknown", () => {
-                let store = newStreamStore({modules: {applicationStore}})
-                store.state.applicationStore.profile = {id: 26}
-                let target = mount(Stream, {store})
+                store.state.stream.name = "Yolo stream"
                 Sinon.spy(console, "error")
-                target.instance().$store.state.streamName = "Yolo stream"
+                let target = mount(Stream, {store})
                 target.instance().stampedElement
                 console.error.getCall(0).args[0].should.eq("Unsupported stream name Yolo stream")
             })
@@ -66,15 +62,6 @@ describe("Stream", () => {
     })
 
     describe("methods", () => {
-        describe("onImageLoad", () => {
-            it("should call Vue.redrawVueMasonry", () => {
-                let target = new Stream({})
-                Sinon.spy(Vue, "redrawVueMasonry")
-                target.onImageLoad()
-                Vue.redrawVueMasonry.called.should.be.true
-            })
-        })
-
         describe("onNewContentClick", () => {
             it("should show the new content button when the user receives new content", (done) => {
                 let target = mount(Stream, {})

--- a/socialhome/streams/app/tests/components/Stream.tests.js
+++ b/socialhome/streams/app/tests/components/Stream.tests.js
@@ -128,8 +128,9 @@ describe("Stream", () => {
 
             // Single content stream
             store.state.stream.single = true
-            store.state.content = getFakeContent()
-            store.state.contents[store.state.content.id] = store.state.content
+            const content = getFakeContent()
+            store.state.singleContentId = content.id
+            store.state.contents[content.id] = content
             target = mount(Stream, {store})
             target.find(".container").length.should.eql(1)
             target.find(".grid-item-full").length.should.eql(1)

--- a/socialhome/streams/app/tests/components/StreamElement.tests.js
+++ b/socialhome/streams/app/tests/components/StreamElement.tests.js
@@ -1,6 +1,7 @@
 import {mount} from "avoriaz"
 import infiniteScroll from "vue-infinite-scroll"
 import Vue from "vue"
+import BootstrapVue from "bootstrap-vue"
 import VueMasonryPlugin from "vue-masonry"
 
 import {getStore} from "streams/app/tests/fixtures/store.fixtures"
@@ -9,6 +10,7 @@ import {streamStoreOperations} from "streams/app/stores/streamStore.operations"
 import StreamElement from "streams/app/components/StreamElement.vue"
 
 
+Vue.use(BootstrapVue)
 Vue.use(infiniteScroll)
 Vue.use(VueMasonryPlugin)
 

--- a/socialhome/streams/app/tests/components/StreamElement.tests.js
+++ b/socialhome/streams/app/tests/components/StreamElement.tests.js
@@ -18,6 +18,7 @@ describe("StreamElement", () => {
     let store
 
     beforeEach(() => {
+        Sinon.restore()
         store = getStore()
     })
 
@@ -72,17 +73,37 @@ describe("StreamElement", () => {
             target.instance().$store.dispatch.getCall(0).args[1].should.eql(store.content.id)
             target.instance().$store.dispatch.getCall(1).args[0].should.eql(streamStoreOperations.loadStream)
         })
-    })
 
-    describe("updated", () => {
-        it("redraws masonry", done => {
-            let target = mount(StreamElement, {propsData: {content: store.content}, store})
-            Sinon.spy(Vue, "redrawVueMasonry")
-            target.update()
-            target.instance().$nextTick(() => {
-            Vue.redrawVueMasonry.called.should.be.true
-                done()
+        describe("onImageLoad", () => {
+            it("should call Vue.redrawVueMasonry if not single stream", () => {
+                let target = mount(StreamElement, {propsData: {content: store.content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.instance().onImageLoad()
+                Vue.redrawVueMasonry.called.should.be.true
+            })
+
+            it("should not call Vue.redrawVueMasonry if single stream", () => {
+                store.state.stream.single = true
+                let target = mount(StreamElement, {propsData: {content: store.content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.instance().onImageLoad()
+                Vue.redrawVueMasonry.called.should.be.false
             })
         })
     })
+
+    describe("lifecycle", () => {
+        describe("updated", () => {
+            it("redraws masonry", done => {
+                let target = mount(StreamElement, {propsData: {content: store.content}, store})
+                Sinon.spy(Vue, "redrawVueMasonry")
+                target.update()
+                target.instance().$nextTick(() => {
+                    Vue.redrawVueMasonry.called.should.be.true
+                    done()
+                })
+            })
+        })
+    })
+
 })

--- a/socialhome/streams/app/tests/fixtures/store.fixtures.js
+++ b/socialhome/streams/app/tests/fixtures/store.fixtures.js
@@ -23,6 +23,11 @@ const getStore = function() {
     Vue.set(store.state.shares, store.share.id, store.share)
     Vue.set(store.state.replies, store.shareReply.id, store.shareReply)
 
+    Vue.set(store.state.stream, "id", "")
+    Vue.set(store.state.stream, "isProfile", false)
+    Vue.set(store.state.stream, "name", "public")
+    Vue.set(store.state.stream, "single", false)
+
     store.state.applicationStore.isUserAuthenticated = true
     store.state.applicationStore.profile = {id: store.content.author.id}
     return store

--- a/socialhome/streams/app/tests/stores/streamStore.tests.js
+++ b/socialhome/streams/app/tests/stores/streamStore.tests.js
@@ -326,6 +326,10 @@ describe("streamStore", () => {
         })
 
         context("when requesting public stream", () => {
+            beforeEach(() => {
+                state.stream = {name: "public"}
+            })
+
             it("should handle public stream request", (done) => {
                 Moxios.stubRequest("/api/streams/public/", response)
 
@@ -368,6 +372,10 @@ describe("streamStore", () => {
         })
 
         context("when requesting followed stream", () => {
+            beforeEach(() => {
+                state.stream = {name: "followed"}
+            })
+
             it("should handle followed stream request", (done) => {
                 Moxios.stubRequest("/api/streams/followed/", response)
 
@@ -410,10 +418,14 @@ describe("streamStore", () => {
         })
 
         context("when requesting tag stream", () => {
-            it("should handle tag stream request", (done) => {
-                Moxios.stubRequest("/api/streams/tag/#yolo/", response)
+            beforeEach(() => {
+                state.stream = {name: "tag", id: "yolo"}
+            })
 
-                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "#yolo"}})
+            it("should handle tag stream request", (done) => {
+                Moxios.stubRequest("/api/streams/tag/yolo/", response)
+
+                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "yolo"}})
 
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
@@ -425,9 +437,9 @@ describe("streamStore", () => {
             })
 
             it("should handle tag stream request with lastId", (done) => {
-                Moxios.stubRequest("/api/streams/tag/#yolo/?last_id=8", response)
+                Moxios.stubRequest("/api/streams/tag/yolo/?last_id=8", response)
 
-                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "#yolo", lastId: 8}})
+                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "yolo", lastId: 8}})
 
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
@@ -439,9 +451,9 @@ describe("streamStore", () => {
             })
 
             it("should handle tag stream request error", (done) => {
-                Moxios.stubRequest("/api/streams/tag/#yolo/", {status: 500})
+                Moxios.stubRequest("/api/streams/tag/yolo/", {status: 500})
 
-                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "#yolo"}})
+                target.dispatch(streamStoreOperations.getTagStream, {params: {name: "yolo"}})
 
                 Moxios.wait(() => {
                     target.state.error.contents.should.exist
@@ -452,6 +464,10 @@ describe("streamStore", () => {
         })
 
         context("when requesting profile all stream", () => {
+            beforeEach(() => {
+                state.stream = {name: "profile_all"}
+            })
+
             it("should handle profile stream request", (done) => {
                 Moxios.stubRequest("/api/streams/profile-all/26/", response)
 
@@ -494,6 +510,10 @@ describe("streamStore", () => {
         })
 
         context("when requesting profile pinned stream", () => {
+            beforeEach(() => {
+                state.stream = {name: "profile_pinned"}
+            })
+
             it("should handle profile stream request", (done) => {
                 Moxios.stubRequest("/api/streams/profile-pinned/26/", response)
 
@@ -749,32 +769,32 @@ describe("streamStore", () => {
                 })
 
                 it("followed stream with no contents", () => {
-                    state.streamName = "followed__spameater"
+                    state.stream = {name: "followed"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql([streamStoreOperations.getFollowedStream, {params: {}}])
                 })
 
                 it("public stream with no contents", () => {
-                    state.streamName = "public"
+                    state.stream = {name: "public"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql([streamStoreOperations.getPublicStream, {params: {}}])
                 })
 
                 it("tag stream with no contents", () => {
-                    state.streamName = "tag__1234"
+                    state.stream = {name: "tag"}
                     state.tagName = "eggs"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql([streamStoreOperations.getTagStream, {params: {name: "eggs"}}])
                 })
 
                 it("profile all stream with no contents", () => {
-                    state.streamName = "profile_all__1234-5678"
+                    state.stream = {name: "profile_all"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql([streamStoreOperations.getProfileAll, {params: {id: 5}}])
                 })
 
                 it("profile pinned stream with no contents", () => {
-                    state.streamName = "profile_pinned__1234-5678"
+                    state.stream = {name: "profile_pinned"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql([streamStoreOperations.getProfilePinned, {params: {id: 5}}])
                 })
@@ -791,7 +811,7 @@ describe("streamStore", () => {
                 })
 
                 it("followed stream with contents", () => {
-                    state.streamName = "followed__spameater"
+                    state.stream = {name: "followed"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
                         [streamStoreOperations.getFollowedStream, {params: {lastId: "4"}}],
@@ -799,7 +819,7 @@ describe("streamStore", () => {
                 })
 
                 it("public stream with contents", () => {
-                    state.streamName = "public"
+                    state.stream = {name: "public"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
                         [streamStoreOperations.getPublicStream, {params: {lastId: "4"}}],
@@ -807,7 +827,7 @@ describe("streamStore", () => {
                 })
 
                 it("tag stream with contents", () => {
-                    state.streamName = "tag__1234"
+                    state.stream = {name: "tag"}
                     state.tagName = "eggs"
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
@@ -816,7 +836,7 @@ describe("streamStore", () => {
                 })
 
                 it("profile all stream with contents", () => {
-                    state.streamName = "profile_all__1234-5678"
+                    state.stream = {name: "profile_all"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
                         [streamStoreOperations.getProfileAll, {params: {id: 5, lastId: "4"}}],
@@ -824,7 +844,7 @@ describe("streamStore", () => {
                 })
 
                 it("profile pinned stream with contents", () => {
-                    state.streamName = "profile_pinned__1234-5678"
+                    state.stream = {name: "profile_pinned"}
                     actions[streamStoreOperations.loadStream]({dispatch, state})
                     dispatch.getCall(0).args.should.eql(
                         [streamStoreOperations.getProfilePinned, {params: {id: 5, lastId: "4"}}],

--- a/socialhome/streams/templatetags/json_context.py
+++ b/socialhome/streams/templatetags/json_context.py
@@ -1,6 +1,8 @@
+import json
+
+from django.utils.html import escapejs
 from django.utils.safestring import mark_safe
 from django.template import Library
-import json
 
 register = Library()
 
@@ -18,7 +20,7 @@ def json_context(context, raise_error=False):
 
     :param context: Current view context
     :param raise_error: Control whether to raise an error on non-JSON serialisable values
-    :return: ``<script>window.context = {<context["json_context"]>}</script>``
+    :return: ``<script>window.context = JSON.parse('{<context["json_context"]>}');</script>``
     """
     if not context.get("json_context"):
         return ""
@@ -26,4 +28,4 @@ def json_context(context, raise_error=False):
     json_default = None if raise_error else lambda obj: str(obj)
 
     json_dump = json.dumps(context["json_context"], default=json_default)
-    return mark_safe("<script>window.context = %s;</script>" % json_dump)
+    return mark_safe("<script>window.context = JSON.parse('%s');</script>" % escapejs(json_dump))

--- a/socialhome/streams/tests/test_templatetags.py
+++ b/socialhome/streams/tests/test_templatetags.py
@@ -16,19 +16,19 @@ class TestJsonContext(SocialhomeTestCase):
                 "variable2": "value2"
             }.items()))
         })
-        result = '<script>window.context = {"variable1": true, "variable2": "value2"};</script>'
-        self.assertEqual(target, result)
+        result = b"<script>window.context = JSON.parse('{\u0022variable1\u0022: true, \u0022variable2\u0022: " \
+                 b"\u0022value2\u0022}');</script>"
+        self.assertEqual(bytes(target, encoding="utf-8"), result)
 
     def test_json_context_with_non_json_serializable_value(self):
         lambda_val = (lambda: "")
-        target = json_context({
+        # Should not raise
+        json_context({
             "json_context": OrderedDict(sorted({
                 "variable1": True,
                 "variable2": lambda_val
             }.items()))
         })
-        result = '<script>window.context = {"variable1": true, "variable2": "%s"};</script>' % lambda_val
-        self.assertEqual(target, result)
 
     def test_json_context_unsafe_raises_with_non_json_serializable_value(self):
         self.assertRaises(TypeError, json_context, {"json_context": {"variable1": lambda: ""}}, True)

--- a/socialhome/streams/tests/test_views.py
+++ b/socialhome/streams/tests/test_views.py
@@ -101,7 +101,7 @@ class TestPublicStreamView(SocialhomeCBVTestCase):
     def test_renders_with_content(self):
         response = self.client.get(reverse("streams:public"))
         assert response.status_code == 200
-        assert self.content.text in str(response.content)
+        assert self.content.get_absolute_url() in str(response.content)
 
     def test_stream_name(self):
         view = self.get_instance(PublicStreamView)
@@ -122,10 +122,10 @@ class TestPublicStreamView(SocialhomeCBVTestCase):
 
     def test_contains_only_public_content(self):
         response = self.client.get(reverse("streams:public"))
-        assert self.content.text in str(response.content)
-        assert self.site.text not in str(response.content)
-        assert self.selff.text not in str(response.content)
-        assert self.limited.text not in str(response.content)
+        assert self.content.get_absolute_url() in str(response.content)
+        assert self.site.get_absolute_url() not in str(response.content)
+        assert self.selff.get_absolute_url() not in str(response.content)
+        assert self.limited.get_absolute_url() not in str(response.content)
 
     def test_logged_in_user(self):
         self.client.force_login(self.user)

--- a/socialhome/users/tests/factories.py
+++ b/socialhome/users/tests/factories.py
@@ -34,9 +34,9 @@ class AdminUserFactory(UserFactory):
 
 class ProfileFactory(factory.django.DjangoModelFactory):
     name = factory.Faker("name")
-    email = factory.Sequence(lambda n: "user-{0}@example.com".format(n))
+    email = factory.Faker("safe_email")
     handle = factory.SelfAttribute("email")
-    guid = factory.Sequence(lambda n: "guid-{0}".format(n))
+    guid = factory.Faker("uuid4")
 
     # Dummy strings as keys since generating these is expensive
     rsa_private_key = fuzzy.FuzzyText()

--- a/socialhome/users/tests/test_models.py
+++ b/socialhome/users/tests/test_models.py
@@ -97,7 +97,10 @@ class TestProfile(SocialhomeTestCase):
         self.assertEqual(self.profile.name_or_handle, self.profile.handle)
 
     def test_remote_url(self):
-        self.assertEqual(self.profile.remote_url, "https://example.com/people/1234")
+        self.assertEqual(
+            self.profile.remote_url,
+            "https://%s/people/%s" % (self.profile.handle.split("@")[1], self.profile.guid)
+        )
 
     def test_profile_image_urls_default_to_ponies(self):
         profile = ProfileFactory(image_url_small="", image_url_medium="", image_url_large="")


### PR DESCRIPTION
Make ContentDetailView render the Vue streams app if vue preference is set.
Tweak streams app to render a single content in case the stream name is
content stream. Some small refactoring to optimize grid stream related
actions only when rendering a grid. Small optimization to store in
preparing a 'stream' object when initializing the app. This will allow to
update the state according to routing events in the future.

Refs: #202

TODO:
* [x] Add test coverage for sigle content vue view