### PR TITLE
Refactor streamStore

### DIFF
--- a/socialhome/streams/app/components/Stream.vue
+++ b/socialhome/streams/app/components/Stream.vue
@@ -44,14 +44,12 @@ import TagStampedElement from "streams/app/components/stamped_elements/TagStampe
 import ProfileStampedElement from "streams/app/components/stamped_elements/ProfileStampedElement.vue"
 import "streams/app/components/LoadingElement.vue"
 
-import {newStreamStore, streamStoreOperations} from "streams/app/stores/streamStore"
-import applicationStore from "streams/app/stores/applicationStore"
+import {streamStoreOperations} from "streams/app/stores/streamStore"
 
 
 Vue.use(VueScrollTo)
 
 export default Vue.component("stream", {
-    store: newStreamStore({modules: {applicationStore}}),
     components: {FollowedStampedElement, PublicStampedElement, ProfileStampedElement, TagStampedElement},
     data() {
         return {
@@ -103,9 +101,6 @@ export default Vue.component("stream", {
         if (!this.$store.state.stream.single) {
             this.$store.dispatch(streamStoreOperations.loadStream)
         }
-    },
-    beforeDestroy() {
-        this.$store.$websocket.close()
     },
 })
 </script>

--- a/socialhome/streams/app/main.js
+++ b/socialhome/streams/app/main.js
@@ -1,15 +1,19 @@
 import Vue from "vue"
 import BootstrapVue from "bootstrap-vue"
-import infiniteScroll from "vue-infinite-scroll"
+import VueInfiniteScroll from "vue-infinite-scroll"
 import VueMasonryPlugin from "vue-masonry"
 
 import Axios from "axios"
 
+import {newStreamStore, streamStoreOperations} from "streams/app/stores/streamStore"
+import applicationStore from "streams/app/stores/applicationStore"
+
 import "streams/app/components/Stream.vue"
+import ReconnectingWebSocket from "ReconnectingWebSocket/reconnecting-websocket.min"
 
 
 Vue.use(BootstrapVue)
-Vue.use(infiniteScroll)
+Vue.use(VueInfiniteScroll)
 Vue.use(VueMasonryPlugin)
 
 Vue.prototype.$http = Axios.create({
@@ -17,6 +21,33 @@ Vue.prototype.$http = Axios.create({
     xsrfHeaderName: "X-CSRFToken",
 })
 
-const main = new Vue({el: "#app"})
+const main = new Vue({
+    el: "#app",
+    store: newStreamStore({
+        modules: {applicationStore},
+        baseURL: "",
+        axios: Vue.prototype.$http,
+    }),
+    methods: {
+        onWebsocketMessage(message) {
+            const data = JSON.parse(message.data)
+
+            if (data.event === "new") {
+                this.$store.dispatch(streamStoreOperations.receivedNewContent, data.id)
+            }
+        },
+        websocketPath() {
+            const websocketProtocol = window.location.protocol === "https:" ? "wss" : "ws"
+            return `${websocketProtocol}://${window.location.host}/ch/streams/${this.$store.state.streamName}/`
+        },
+    },
+    created() {
+        this.$websocket = new ReconnectingWebSocket(this.websocketPath())
+        this.$websocket.onmessage = message => this.onWebsocketMessage(message)
+    },
+    beforeDestroy() {
+        this.$websocket.close()
+    },
+})
 
 export default main

--- a/socialhome/streams/app/tests/components/Stream.tests.js
+++ b/socialhome/streams/app/tests/components/Stream.tests.js
@@ -10,6 +10,8 @@ import FollowedStampedElement from "streams/app/components/stamped_elements/Foll
 import {streamStoreOperations} from "streams/app/stores/streamStore"
 import {getStore} from "streams/app/tests/fixtures/store.fixtures"
 import {getFakeContent} from "streams/app/tests/fixtures/jsonContext.fixtures"
+import applicationStore from "../../stores/applicationStore"
+import {newStreamStore} from "../../stores/streamStore"
 
 
 Vue.use(BootstrapVue)
@@ -65,7 +67,8 @@ describe("Stream", () => {
     describe("methods", () => {
         describe("onNewContentClick", () => {
             it("should show the new content button when the user receives new content", (done) => {
-                let target = mount(Stream, {})
+                store.state.stream.name = "" // Deactivate posts fetching
+                let target = mount(Stream, {store})
                 target.find(".new-content-container")[0].hasStyle("display", "none").should.be.true
                 target.instance().$store.commit(streamStoreOperations.receivedNewContent, 1)
                 target.instance().$nextTick(() => {
@@ -76,7 +79,7 @@ describe("Stream", () => {
             })
 
             it("should acknowledge new content when the user clicks the button", () => {
-                let target = mount(Stream, {})
+                let target = mount(Stream, {store})
                 target.instance().$store.commit(streamStoreOperations.receivedNewContent, 1)
                 Sinon.spy(target.instance().$store, "dispatch")
                 target.find(".new-content-load-link")[0].trigger("click")
@@ -105,7 +108,9 @@ describe("Stream", () => {
 
         describe("render", () => {
             it("should not render unfetched content", () => {
-                let target = mount(Stream, {})
+                store = newStreamStore({modules: {applicationStore}})
+                store.state.stream.name = ""
+                let target = mount(Stream, {store})
                 target.find(".grid-item").length.should.eq(0)
                 target.instance().$store.commit(streamStoreOperations.receivedNewContent, 1)
                 target.find(".grid-item").length.should.eq(0)

--- a/socialhome/streams/app/tests/fixtures/store.fixtures.js
+++ b/socialhome/streams/app/tests/fixtures/store.fixtures.js
@@ -3,10 +3,18 @@ import Vue from "vue"
 import {getFakeContent} from "streams/app/tests/fixtures/jsonContext.fixtures"
 import {newStreamStore} from "streams/app/stores/streamStore"
 import applicationStore from "streams/app/stores/applicationStore"
+import Axios from "axios"
 
 
-const getStore = function() {
-    let store = newStreamStore({ modules: { applicationStore } })
+const getStore = function () {
+    let store = newStreamStore({
+        modules: {applicationStore},
+        baseURL: "",
+        axios: Axios.create({
+            xsrfCookieName: "csrftoken",
+            xsrfHeaderName: "X-CSRFToken",
+        }),
+    })
     store.content = getFakeContent()
     store.reply = getFakeContent({parent: store.content.id, content_type: "reply"})
     store.share = getFakeContent({share_of: store.content.id, content_type: "share"})

--- a/socialhome/streams/app/tests/main.tests.js
+++ b/socialhome/streams/app/tests/main.tests.js
@@ -1,6 +1,8 @@
-import "streams/app/main"
+import main from "streams/app/main"
 
 import Vue from "vue"
+import Vuex from "vuex"
+import {streamStoreOperations} from "../stores/streamStore"
 
 
 describe("Main", () => {
@@ -16,5 +18,56 @@ describe("Main", () => {
 
     it("Vue.redrawVueMasonry is defined", () => {
         (typeof Vue.redrawVueMasonry).should.equal("function")
+    })
+
+    describe("`main` instance", () => {
+        describe("methods", () => {
+            describe("onWebsocketMessage", () => {
+                it("should dispatch receivedNewContent to store when serveur sends a next message", () => {
+                    Sinon.spy(main.$store, "dispatch")
+                    main.onWebsocketMessage({data: JSON.stringify({event: "new", id: 4})})
+                    main.$store.dispatch.getCall(0).args
+                        .should.eql([streamStoreOperations.receivedNewContent, 4])
+                })
+            })
+
+            describe("websocketPath", () => {
+                it("should connect with protocol wss:// when browser protocol is HTTPS", () => {
+                    jsdom.reconfigure({url: "https://localhost"})
+                    main.$store.state.streamName = "public"
+
+                    main.websocketPath().should.eq("wss://localhost/ch/streams/public/")
+                })
+
+                it("should connect with protocol ws:// when browser protocol is HTTP", () => {
+                    jsdom.reconfigure({url: "http://localhost"})
+                    main.$store.state.streamName = "public"
+
+                    main.websocketPath().should.eq("ws://localhost/ch/streams/public/")
+                })
+            })
+        })
+    })
+    describe("Lifecycle", () => {
+        describe("created", () => {
+            it("should initialize `main.$websocket`", () => {
+                main.$websocket.should.exist
+            })
+
+            it("should initialize `main.$websocket.onmessage`", () => {
+                Sinon.spy(main, "onWebsocketMessage")
+                let msg = {data: JSON.stringify({event: "new", id: 4})}
+                main.$websocket.onmessage(msg)
+                main.onWebsocketMessage.getCall(0).args.should.eql([{data: JSON.stringify({event: "new", id: 4})}])
+            })
+        })
+
+        describe("beforeDestroy", () => {
+            it("should call `main.$websocket.close`", () => {
+                let spy = Sinon.spy(main.$websocket, "close")
+                main.$destroy()
+                spy.called.should.be.true
+            })
+        })
     })
 })


### PR DESCRIPTION
First step towards better use Vuex stores like advised in official documentation

- [x] Move websocket out of streamStore and attach to the Vue singleton
- [x] Simplify streamStore creation
- [x] Attach store singleton to Vue  singleton instead of Stream component
- [x] Refactor tests
