### PR TITLE
Twitter streams OEmbed refactor

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,8 @@ Added
 
 * Installation docs now have an example SystemD service configuration, see :ref:`installation-other-systemd`. (`#397 <https://github.com/jaywink/socialhome/issues/397>`_)
 
+* Content API has a new read only field ``has_twitter_oembed``. This is ``true`` if the content text had a Tweet URL *and* a fetch for the OEmbed code has been successfully made.
+
 Changed
 .......
 

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -164,6 +164,10 @@ class Content(models.Model):
         return reverse("content:view", kwargs={"pk": self.id})
 
     @property
+    def has_twitter_oembed(self):
+        return self.rendered.find('class="twitter-tweet"') > -1
+
+    @property
     def humanized_timestamp(self):
         """Human readable timestamp ie '2 hours ago'."""
         return arrow.get(self.modified).humanize()

--- a/socialhome/content/serializers.py
+++ b/socialhome/content/serializers.py
@@ -25,6 +25,7 @@ class ContentSerializer(serializers.ModelSerializer):
             "content_type",
             "edited",
             "guid",
+            "has_twitter_oembed",
             "humanized_timestamp",
             "id",
             "is_nsfw",
@@ -53,6 +54,7 @@ class ContentSerializer(serializers.ModelSerializer):
             "content_type"
             "edited",
             "guid",
+            "has_twitter_oembed",
             "humanized_timestamp",
             "id",
             "is_nsfw",
@@ -122,4 +124,3 @@ class ContentSerializer(serializers.ModelSerializer):
             if not value.visible_for_user(request.user):
                 raise serializers.ValidationError("Parent not found")
         return value
-

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -46,6 +46,7 @@ class TestContentModel(SocialhomeTestCase):
         cls.set = {
             cls.public_content, cls.site_content, cls.limited_content, cls.self_content
         }
+        cls.content_with_twitter_oembed = ContentFactory(text='class="twitter-tweet"')
 
     def setUp(self):
         super().setUp()
@@ -141,6 +142,12 @@ class TestContentModel(SocialhomeTestCase):
         # Do a share
         self.public_content.share(self.local_user.profile)
         self.assertTrue(Content.has_shared(self.public_content.id, self.local_user.profile.id))
+
+    def test_has_twitter_oembed__no_oembed(self):
+        self.assertFalse(self.public_content.has_twitter_oembed)
+
+    def test_has_twitter_oembed__contains_oembed(self):
+        self.assertTrue(self.content_with_twitter_oembed.has_twitter_oembed)
 
     def test_is_local(self):
         self.assertFalse(self.site_content.local)

--- a/socialhome/content/tests/test_serializers.py
+++ b/socialhome/content/tests/test_serializers.py
@@ -88,6 +88,10 @@ class ContentSerializerTestCase(SocialhomeTestCase):
         self.assertEqual(content.visibility, Visibility.LIMITED)
         self.assertEqual(content.parent, self.limited_content2)
 
+    def test_has_twitter_oembed(self):
+        serializer = ContentSerializer(self.content)
+        self.assertFalse(serializer.data["has_twitter_oembed"])
+
     def test_serializes_author(self):
         serializer = ContentSerializer(self.content)
         data = serializer.data["author"]

--- a/socialhome/streams/app/stores/streamStore.js
+++ b/socialhome/streams/app/stores/streamStore.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import Vue from "vue"
 import Vuex from "vuex"
 import Vapi from "vuex-rest-api"
@@ -15,6 +16,7 @@ function addHasLoadMore(state) {
     const loadMoreContentId = state.contentIds[state.contentIds.length - 6]
     if (loadMoreContentId) {
         Vue.set(state.contents[loadMoreContentId], "hasLoadMore", true)
+        state.layoutDoneAfterTwitterOEmbeds = false
     }
 }
 

--- a/socialhome/streams/app/stores/streamStore.operations.js
+++ b/socialhome/streams/app/stores/streamStore.operations.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 import Vue from "vue"
 import _concat from "lodash/concat"
 import _difference from "lodash/difference"
@@ -17,6 +18,7 @@ const streamStoreOperations = {
     newContentAck: "newContentAck",
     receivedNewContent: "receivedNewContent",
     saveReply: "saveReply",
+    setLayoutDoneAfterTwitterOEmbeds: "setLayoutDoneAfterTwitterOEmbeds",
 }
 
 const mutations = {
@@ -25,6 +27,9 @@ const mutations = {
     },
     [streamStoreOperations.receivedNewContent](state, contentId) {
         state.unfetchedContentIds.push(contentId)
+    },
+    [streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds](state, status) {
+        state.layoutDoneAfterTwitterOEmbeds = status
     },
     [streamStoreOperations.newContentAck](state) {
         /*
@@ -75,6 +80,9 @@ const actions = {
     },
     [streamStoreOperations.receivedNewContent]({commit}, newContentLengh) {
         commit(streamStoreOperations.receivedNewContent, newContentLengh)
+    },
+    [streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds]({commit}, status) {
+        commit(streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds, status)
     },
     [streamStoreOperations.newContentAck]({commit, dispatch, state}) {
         commit(streamStoreOperations.newContentAck)

--- a/socialhome/streams/app/stores/streamStore.state.js
+++ b/socialhome/streams/app/stores/streamStore.state.js
@@ -32,6 +32,7 @@ export default function () {
         contents,
         contentIds,
         hasNewContent: false,
+        layoutDoneAfterTwitterOEmbeds: false,
         newContentLengh: 0,
         replies,
         shares,

--- a/socialhome/streams/app/tests/stores/streamStore.tests.js
+++ b/socialhome/streams/app/tests/stores/streamStore.tests.js
@@ -6,7 +6,7 @@ import Vuex from "vuex"
 
 import {actions, mutations, getters} from "streams/app/stores/streamStore.operations"
 import {getFakeContent} from "streams/app/tests/fixtures/jsonContext.fixtures"
-import {newStreamStore, streamStoreOperations, exportsForTests} from "streams/app/stores/streamStore"
+import {streamStoreOperations, exportsForTests} from "streams/app/stores/streamStore"
 import getState from "streams/app/stores/streamStore.state"
 import Axios from "axios/index"
 
@@ -42,6 +42,19 @@ describe("streamStore", () => {
             state.contents[state.contentIds[1]].hasLoadMore.should.be.false
             state.contents[state.contentIds[2]].hasLoadMore.should.be.false
             state.contents[state.contentIds[3]].hasLoadMore.should.be.false
+        })
+
+        it("sets layoutDoneAfterTwitterOEmbeds to false", () => {
+            const state = {
+                contentIds: [...new Array(7).keys()].map(i => i),
+                contents: {},
+                layoutDoneAfterTwitterOEmbeds: true,
+            }
+            state.contentIds.forEach(id => {
+                state.contents[id] = getFakeContent({id: id, hasLoadMore: false})
+            })
+            exportsForTests.addHasLoadMore(state)
+            state.layoutDoneAfterTwitterOEmbeds.should.be.false
         })
     })
 
@@ -626,10 +639,12 @@ describe("streamStore", () => {
             target.actions[streamStoreOperations.newContentAck].should.exist
             target.actions[streamStoreOperations.receivedNewContent].should.exist
             target.actions[streamStoreOperations.saveReply].should.exist
+            target.actions[streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds].should.exist
 
             target.mutations[streamStoreOperations.disableLoadMore].should.exist
             target.mutations[streamStoreOperations.newContentAck].should.exist
             target.mutations[streamStoreOperations.receivedNewContent].should.exist
+            target.mutations[streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds].should.exist
 
             for(let getter in getters) {
                 target.getters[getter].should.exist
@@ -655,6 +670,7 @@ describe("streamStore", () => {
                 state.unfetchedContentIds.should.eql(["6"])
             })
         })
+
         describe("newContentAck", () => {
             it("should add all elements from 'state.unfetchedContentIds' to 'state.contentIds'", () => {
                 let state = {unfetchedContentIds: ["6"], contentIds: []}
@@ -665,6 +681,16 @@ describe("streamStore", () => {
                 let state = {unfetchedContentIds: ["6"], contentIds: ["6"]}
                 mutations[streamStoreOperations.newContentAck](state)
                 state.contentIds.should.eql(["6"])
+            })
+        })
+
+        describe("setLayoutDoneAfterTwitterOEmbeds", () => {
+            it("should set the state correctly", () => {
+                let state = {layoutDoneAfterTwitterOEmbeds: false}
+                mutations[streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds](state, true)
+                state.layoutDoneAfterTwitterOEmbeds.should.be.true
+                mutations[streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds](state, false)
+                state.layoutDoneAfterTwitterOEmbeds.should.be.false
             })
         })
     })
@@ -816,6 +842,17 @@ describe("streamStore", () => {
                     .onCall(2).returns(Promise.resolve())
 
                 actions[streamStoreOperations.newContentAck]({commit, state, dispatch}).should.be.fulfilled.notify(done)
+            })
+        })
+
+        describe("setLayoutDoneAfterTwitterOEmbeds", () => {
+            it("should commit mutation correctly", () => {
+                // let state = {layoutDoneAfterTwitterOEmbeds: false}
+                let commit = Sinon.spy()
+                // let dispatch = Sinon.spy()
+                actions[streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds]({commit}, true)
+                commit.getCall(0).args[0].should.equal(streamStoreOperations.setLayoutDoneAfterTwitterOEmbeds)
+                commit.getCall(0).args[1].should.be.true
             })
         })
     })

--- a/socialhome/streams/templates/streams/includes/_twitter_widget.html
+++ b/socialhome/streams/templates/streams/includes/_twitter_widget.html
@@ -1,0 +1,21 @@
+<div id="twttr-script-container"></div>
+<script>
+    /* Twitter widget script loader
+       from: https://dev.twitter.com/web/javascript/loading
+    */
+    window.twttr = (function(d, s, id) {
+        var js, fjs = d.getElementById("twttr-script-container"),
+            t = window.twttr || {};
+        if (d.getElementById(id)) return t;
+        js = d.createElement(s);
+        js.id = id;
+        js.src = "https://platform.twitter.com/widgets.js";
+        fjs.parentNode.insertBefore(js, fjs);
+
+        t._e = [];
+        t.ready = function(f) {
+            t._e.push(f);
+        };
+        return t;
+    }(document, "script", "twitter-wjs"));
+</script>

--- a/socialhome/streams/templates/streams/vue.html
+++ b/socialhome/streams/templates/streams/vue.html
@@ -15,6 +15,7 @@
     {{ block.super }}
     <script type="text/javascript" charset="utf-8">{% js_reverse_inline %}</script>
     <script src="{% static 'js/webpack.stream.js' %}"></script>
+    {% include "streams/includes/_twitter_widget.html" %}
 {% endblock %}
 
 


### PR DESCRIPTION
Fix (or hack around) how Masonry layout is done in Vue streams for Twitter OEmbed widgets.

* Load widget script once in base template
* Do a layout (hackily) after 2 and 4 seconds (if oembed's), to ensure Twitter widget has had time to load content
* Add `has_twitter_oembed` to Content API as a read only field

TODO:
* [x] ~~Check~~ Ensure layouting triggers after load more
  - Clear the flag on load more?
* [x] Trigger widgets script after Vue initialized... how and where from?
  - Maybe call `twttr.widgets.load()` after each mount of streamelement with twitter oembed content?

Refs: #202