### PR TITLE
Various organize pinned content fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -49,6 +49,11 @@ Changed
 
   Replies are created by simply passing in a ``parent`` with the ID value of the target Content. It is not possible to change the ``parent`` value for an existing reply or root level Content object once created. When creating a reply, you can omit ``visibility`` from the sent data. Visibility will be used from the parent Content item automatically.
 
+Fixed
+.....
+
+* Redirect back to profile instead of home view after organize pinned content save action. (`#313 <https://github.com/jaywink/socialhome/issues/313>`_)
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/socialhome/streams/app/components/stamped_elements/ProfileStampedElement.vue
+++ b/socialhome/streams/app/components/stamped_elements/ProfileStampedElement.vue
@@ -48,7 +48,7 @@
                     <i class="fa fa-envelope"></i> {{ translations.email }}
                 </b-dropdown-item>
                 <b-dropdown-item
-                    v-if=""
+                    v-if="profile.has_pinned_content"
                     :href="urls.organizeProfileUrl"
                     :title="translations.organizeProfileContent"
                     :aria-label="translations.organizeProfileContent"

--- a/socialhome/users/tests/test_views.py
+++ b/socialhome/users/tests/test_views.py
@@ -243,7 +243,7 @@ class TestOrganizeContentUserDetailView(SocialhomeTestCase):
 
     def test_get_success_url(self):
         request, view, contents, profile = self._get_request_view_and_content()
-        assert view.get_success_url() == "/"
+        assert view.get_success_url() == "/u/%s/" % profile.user.username
 
 
 @pytest.mark.usefixtures("admin_user", "client")

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -151,7 +151,7 @@ class OrganizeContentProfileDetailView(ProfileDetailView):
                 Content.objects.filter(id=card_id).update(order=i)
 
     def get_success_url(self):
-        return reverse("home")
+        return reverse("users:detail", kwargs={"username": self.request.user.username})
 
 
 class ProfileUpdateView(LoginRequiredMixin, UpdateView):

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -153,6 +153,10 @@ class OrganizeContentProfileDetailView(ProfileDetailView):
     def get_success_url(self):
         return reverse("users:detail", kwargs={"username": self.request.user.username})
 
+    def get_template_names(self):
+        """Override to not render Vue template if that is active."""
+        return [self.template_name]
+
 
 class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     form_class = ProfileForm


### PR DESCRIPTION
* Redirect back to profile instead of home view after organize pinned content save action
* Don't show organize profile link unless there is pinned content 
* Fix organize profile content view not rendering if Vue stream active

Closes #313
Refs #202