### PR TITLE
Fix direct profile search when using uppercase search term

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,8 @@ Fixed
 
 * Redirect back to profile instead of home view after organize pinned content save action. (`#313 <https://github.com/jaywink/socialhome/issues/313>`_)
 
+* Fix searching of an unknown remote profile by handle using uppercase letters resulting in an invalid local profile creation.
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/socialhome/search/tests/test_views.py
+++ b/socialhome/search/tests/test_views.py
@@ -11,7 +11,7 @@ from socialhome.enums import Visibility
 from socialhome.search.views import GlobalSearchView
 from socialhome.tests.utils import SocialhomeCBVTestCase, SocialhomeTestCase
 from socialhome.users.models import Profile
-from socialhome.users.tests.factories import ProfileFactory, UserFactory, PublicProfileFactory
+from socialhome.users.tests.factories import ProfileFactory, UserFactory, PublicProfileFactory, BaseProfileFactory
 from socialhome.users.views import ProfileAllContentView
 
 
@@ -100,3 +100,9 @@ class TestGlobalSearchView(SocialhomeTestCase):
         self.assertResponseNotContains("Results", html=False)
         self.assertEqual(self.context["view"].__class__, ProfileAllContentView)
         self.assertEqual(self.context["object"], profile)
+
+    @patch("socialhome.search.views.retrieve_remote_profile", autospec=True)
+    def test_search_by_handle_lowercases_before_fetching(self, mock_retrieve):
+        mock_retrieve.return_value = BaseProfileFactory()
+        self.get("%s?q=%s" % (reverse("search:global"), "i-dont-EXIST-locally@eXample.com"), follow=True)
+        mock_retrieve.assert_called_once_with("i-dont-exist-locally@example.com")

--- a/socialhome/search/views.py
+++ b/socialhome/search/views.py
@@ -8,7 +8,6 @@ from haystack.generic_views import SearchView
 from socialhome.content.utils import safe_text
 from socialhome.enums import Visibility
 from socialhome.users.models import Profile
-from socialhome.users.views import ProfileDetailView
 
 
 class GlobalSearchView(SearchView):
@@ -31,7 +30,7 @@ class GlobalSearchView(SearchView):
         try:
             q = safe_text(request.GET.get("q"))
             if q:
-                q = q.strip()
+                q = q.strip().lower()
             validate_email(q)
         except ValidationError:
             pass

--- a/socialhome/users/models.py
+++ b/socialhome/users/models.py
@@ -163,6 +163,8 @@ class Profile(TimeStampedModel):
             for idx, attr in enumerate(["image_url_large", "image_url_medium", "image_url_small"]):
                 if not getattr(self, attr, None):
                     setattr(self, attr, ponies[idx])
+        # Ensure handle is *always* lowercase
+        self.handle = self.handle.lower()
         super().save(*args, **kwargs)
 
     @property


### PR DESCRIPTION
Always lower case handle when fetching remote profiles in search

This should be handled in federation library too, but no hurt fixing
it here as well.