### PR TITLE
Fix incorrect throughs values when collecting content in Streams

### DIFF
--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -21,7 +21,7 @@ from memoize import memoize, delete_memoized
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField
 
 from socialhome.content.enums import ContentType
-from socialhome.content.querysets import TagQuerySet, ContentQuerySet
+from socialhome.content.querysets import TagQuerySet, ContentManager
 from socialhome.content.utils import make_nsfw_safe, test_tag, process_text_links
 from socialhome.enums import Visibility
 from socialhome.users.models import Profile
@@ -127,7 +127,7 @@ class Content(models.Model):
     reply_count = models.PositiveIntegerField(_("Reply count"), default=0, editable=False)
     shares_count = models.PositiveIntegerField(_("Shares count"), default=0, editable=False)
 
-    objects = ContentQuerySet.as_manager()
+    objects = ContentManager()
 
     def __str__(self):
         return "{text} ({guid})".format(

--- a/socialhome/streams/streams.py
+++ b/socialhome/streams/streams.py
@@ -184,11 +184,11 @@ class BaseStream:
                 qs = qs.filter(id__lt=self.last_id)
             else:
                 qs = qs.filter(id__gt=self.last_id)
-        ids.extend(qs.values_list("id", flat=True).order_by(self.ordering)[:remaining])
-        # Fill remaining throughs
-        for id in ids:
-            if not throughs.get(id):
-                throughs[id] = id
+        # Get and fill remaining items
+        ids_throughs = qs.values("id", "through").order_by(self.ordering)[:remaining]
+        for item in ids_throughs:
+            ids.append(item["id"])
+            throughs[item["id"]] = item["through"]
         return ids, throughs
 
     def get_queryset(self):


### PR DESCRIPTION
Previously we set share through as content.id for any shares included in
streams via DB lookups. This caused a problem of missing content in new
streams and infinite load on old streams. By adding through to all content
querysets and then correctly populating it for shares, we can now produce
a correct through value for content included in streams through shares
in DB lookups too.

Fixes #412