### PR TITLE
Several fixes to load more and querysets

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -56,6 +56,10 @@ Fixed
 
 * Fix searching of an unknown remote profile by handle using uppercase letters resulting in an invalid local profile creation.
 
+* Fix Content querysets not correctly including the 'through' information which tells what content caused a share to be added to a stream. (`#412 <https://github.com/jaywink/socialhome/issues/412>`_)
+
+  This information was already correctly added in the streams precalculation phase, but if the cache started cold or a viewing user cycled through all cached content ID's and wanted some more, the database queries did not return the right results.
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/socialhome/streams/app/stores/streamStore.js
+++ b/socialhome/streams/app/stores/streamStore.js
@@ -16,8 +16,11 @@ function addHasLoadMore(state) {
     const loadMoreContentId = state.contentIds[state.contentIds.length - 6]
     if (loadMoreContentId) {
         Vue.set(state.contents[loadMoreContentId], "hasLoadMore", true)
-        state.layoutDoneAfterTwitterOEmbeds = false
+    } else {
+        // Add to the last to be sure we always add it
+        Vue.set(state.contents[state.contentIds[state.contentIds.length - 1]], "hasLoadMore", true)
     }
+    state.layoutDoneAfterTwitterOEmbeds = false
 }
 
 function fetchContentsSuccess(state, payload) {

--- a/socialhome/streams/app/stores/streamStore.js
+++ b/socialhome/streams/app/stores/streamStore.js
@@ -24,14 +24,16 @@ function addHasLoadMore(state) {
 }
 
 function fetchContentsSuccess(state, payload) {
+    let newItems = 0
     payload.data.forEach(item => {
         const content = Object.assign({}, item, {replyIds: [], shareIds: []})
         Vue.set(state.contents, content.id, content)
         if (state.contentIds.indexOf(content.id) === -1) {
             state.contentIds.push(content.id)
+            newItems += 1
         }
     })
-    if (payload.data.length) {
+    if (newItems > 0) {
         addHasLoadMore(state)
     }
 }

--- a/socialhome/streams/app/tests/stores/streamStore.tests.js
+++ b/socialhome/streams/app/tests/stores/streamStore.tests.js
@@ -33,7 +33,7 @@ describe("streamStore", () => {
             state.contents[state.contentIds[6]].hasLoadMore.should.be.false
         })
 
-        it("does not add flag if under 5 contents", () => {
+        it("adds flag to last if under 5 contents", () => {
             const state = {contentIds: [...new Array(4).keys()].map(i => i), contents: {}}
             state.contentIds.forEach(id => {
                 state.contents[id] = getFakeContent({id: id, hasLoadMore: false})
@@ -42,7 +42,7 @@ describe("streamStore", () => {
             state.contents[state.contentIds[0]].hasLoadMore.should.be.false
             state.contents[state.contentIds[1]].hasLoadMore.should.be.false
             state.contents[state.contentIds[2]].hasLoadMore.should.be.false
-            state.contents[state.contentIds[3]].hasLoadMore.should.be.false
+            state.contents[state.contentIds[3]].hasLoadMore.should.be.true
         })
 
         it("sets layoutDoneAfterTwitterOEmbeds to false", () => {
@@ -86,10 +86,18 @@ describe("streamStore", () => {
                     "1": {id: "1", text: "Plop", content_type: "content", replyIds: [], shareIds: []},
                     "2": {id: "2", text: "Hello!", content_type: "content", replyIds: [], shareIds: []},
                     "6": {id: "6", text: "foobar", content_type: "content", replyIds: [], shareIds: []},
-                    "7": {id: "7", text: "blablabla", content_type: "content", replyIds: [], shareIds: []},
+                    "7": {
+                        id: "7",
+                        text: "blablabla",
+                        content_type: "content",
+                        replyIds: [],
+                        shareIds: [],
+                        hasLoadMore: true,
+                    },
                 },
                 replies: {},
                 shares: {},
+                layoutDoneAfterTwitterOEmbeds: false,
             })
         })
     })
@@ -284,7 +292,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -298,7 +306,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -330,7 +338,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -344,7 +352,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -376,7 +384,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -390,7 +398,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -422,7 +430,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -436,7 +444,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -468,7 +476,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })
@@ -482,7 +490,7 @@ describe("streamStore", () => {
                 Moxios.wait(() => {
                     target.state.contents.should.eql({
                         "6": {id: "6", text: "foobar", replyIds: [], shareIds: []},
-                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: []},
+                        "7": {id: "7", text: "blablabla", replyIds: [], shareIds: [], hasLoadMore: true},
                     })
                     done()
                 })

--- a/socialhome/streams/streams.py
+++ b/socialhome/streams/streams.py
@@ -181,9 +181,9 @@ class BaseStream:
         qs = self.get_queryset()
         if self.last_id:
             if self.ordering == "-created":
-                qs = qs.filter(id__lt=self.last_id)
+                qs = qs.filter(through__lt=self.last_id)
             else:
-                qs = qs.filter(id__gt=self.last_id)
+                qs = qs.filter(through__gt=self.last_id)
         # Get and fill remaining items
         ids_throughs = qs.values("id", "through").order_by(self.ordering)[:remaining]
         for item in ids_throughs:


### PR DESCRIPTION
* Fix Content querysets not correctly including 'through'

  This is the information which tells what content caused a share to be added to a stream.

  This information was already correctly added in the streams precalculation phase, but if the cache started cold or a viewing user cycled through all cached content ID's and wanted some more, the database queries did not return the right results.

* Always add load more trigger on any content received

  Sometimes our backend might return duplicates on some shared content when it crosses the boundary of precalculated/fetched from db. Ensure we still add load more even if one content is received, to minimize the risk of having a "stuck stream".

* Correctly filter on through, not id, when using last_id and db lookup

  Precalculated last_id worked fine before but now fixed db lookups to
  correctly use through as the last_id filter, not id. This is important
  when results have shares.

* Only add loadMore to stream if new items

  Stops endless requests being made to backend.

Together these close #412.