### PR TITLE
Preserve order of urls when fetching content previews

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -64,6 +64,10 @@ Fixed
 
   This information was already correctly added in the streams precalculation phase, but if the cache started cold or a viewing user cycled through all cached content ID's and wanted some more, the database queries did not return the right results.
 
+* Attempt to fetch OEmbed and OpenGraph previews of URL's in content in the order of the links found. (`#365 <https://github.com/jaywink/socialhome/issues/365>`_)
+
+  Previous behaviour lead to fetching previews of urls in random order, leading to a different url preview on different Socialhome servers.
+
 0.6.0 (2017-11-13)
 ------------------
 

--- a/socialhome/content/tests/test_utils.py
+++ b/socialhome/content/tests/test_utils.py
@@ -97,34 +97,39 @@ class TestFindUrlsInText(TestCase):
                                 "<a href=\"https://example.net\">bar</a>" \
                                 "[waat](https://example.org)"
         cls.without_protocol = "example.org"
+        cls.many_for_ordered = "http://spam.com http://eggs.com http://spam.com"
+
+    def test_returns_in_order_without_duplicates(self):
+        urls = find_urls_in_text(self.many_for_ordered)
+        self.assertEqual(urls, ["http://spam.com", "http://eggs.com"])
 
     def test_starts_with_url(self):
         urls = find_urls_in_text(self.starts_with_url)
-        self.assertEqual(urls, {self.starts_with_url})
+        self.assertEqual(urls, [self.starts_with_url])
         urls = find_urls_in_text(self.http_starts_with_url)
-        self.assertEqual(urls, {self.http_starts_with_url})
+        self.assertEqual(urls, [self.http_starts_with_url])
 
     def test_numbers(self):
         urls = find_urls_in_text(self.numbers)
-        self.assertEqual(urls, {self.numbers})
+        self.assertEqual(urls, [self.numbers])
 
     def test_special_chars(self):
         urls = find_urls_in_text(self.special_chars)
-        self.assertEqual(urls, {self.special_chars})
+        self.assertEqual(urls, [self.special_chars])
 
     def test_urls_in_text(self):
         urls = find_urls_in_text(self.urls_in_text)
-        self.assertEqual(urls, {
+        self.assertEqual(urls, [
             "https://example1.com", "https://example2.com", "https://example-3.com"
-        })
+        ])
 
     def test_href_markdown(self):
         urls = find_urls_in_text(self.href_and_markdown)
-        self.assertEqual(urls, {"https://example.com", "https://example.net", "https://example.org"})
+        self.assertEqual(urls, ["https://example.com", "https://example.net", "https://example.org"])
 
     def test_without_protocol(self):
         urls = find_urls_in_text(self.without_protocol)
-        self.assertEqual(urls, {"http://example.org"})
+        self.assertEqual(urls, ["http://example.org"])
 
 
 class TestProcessTextLinks(TestCase):

--- a/socialhome/content/utils.py
+++ b/socialhome/content/utils.py
@@ -104,17 +104,19 @@ def find_urls_in_text(text):
     Bleach does the heavy lifting here by identifying the links.
 
     :param text: Text to search links from
-    :returns: set of urls
+    :returns: list of urls with duplicates removed
     """
     urls = []
 
     def link_collector(attrs, new=False):
         href_key = (None, "href")
-        urls.append(attrs.get(href_key))
+        url = attrs.get(href_key)
+        if url not in urls:
+            urls.append(url)
         return None
 
     bleach.linkify(text, callbacks=[link_collector], parse_email=False, skip_tags=["code"])
-    return set(urls)
+    return urls
 
 
 def test_tag(tag):


### PR DESCRIPTION
Attempt to fetch OEmbed and OpenGraph previews of URL's in content in the order of the links found.

Previous behaviour lead to fetching previews of urls in random order, leading to a different url preview on different Socialhome servers.

Closes #365