### PR TITLE
Make signup link point to node list if signups are closed

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -193,6 +193,7 @@ FORM_RENDERER = "django.forms.renderers.TemplatesSetting"
 # Settings export
 SETTINGS_EXPORT = [
     "ACCOUNT_ALLOW_REGISTRATION",
+    "SOCIALHOME_NODE_LIST_URL",
 ]
 
 # See: http://django-crispy-forms.readthedocs.org/en/latest/install.html#template-packs
@@ -317,6 +318,8 @@ if SOCIALHOME_ADDITIONAL_APPS:
 SOCIALHOME_ADDITIONAL_APPS_URLS = env("SOCIALHOME_ADDITIONAL_APPS_URLS", default=None)
 # Allow to use on main page custom view from third-party app
 SOCIALHOME_HOME_VIEW = env("SOCIALHOME_HOME_VIEW", default=None)
+# If signups are closed, make signup link point here
+SOCIALHOME_NODE_LIST_URL = env("SOCIALHOME_NODE_LIST_URL", default="https://the-federation.info/socialhome")
 
 # Streams
 # Trim precached streams to this maximum size

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,10 @@ Added
 
   The content will still update to local streams normally. Federating the content can be enabled on further saves.
 
+* If signups are closed, the signup link will now stay active but will point to a list of Socialhome nodes. (`#354 <https://github.com/jaywink/socialhome/issues/354>`_)
+
+  By default this URL is https://the-federation.info/socialhome, but can be configured by the server admin.
+
 Changed
 .......
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -274,6 +274,13 @@ Default: ``/tmp/socialhome.log``
 
 Where to write the main application log.
 
+SOCIALHOME_NODE_LIST_URL
+........................
+
+Default: ``https://the-federation.info/socialhome``
+
+URL to make signup link go to in the case that signups are closed.
+
 SOCIALHOME_RELAY_DOMAIN
 .......................
 

--- a/socialhome/templates/base.html
+++ b/socialhome/templates/base.html
@@ -61,11 +61,11 @@
                             <a class="nav-link" href="{% url "account_logout" %}">{% trans "Logout" %}</a>
                         </li>
                     {% else %}
-                        {% if settings.ACCOUNT_ALLOW_REGISTRATION %}
-                            <li class="nav-item">
-                                <a id="sign-up-link" class="nav-link" href="{% url "account_signup" %}">{% trans "Sign Up" %}</a>
-                            </li>
-                        {% endif %}
+                        <li class="nav-item">
+                            <a id="sign-up-link" class="nav-link" href="{% if settings.ACCOUNT_ALLOW_REGISTRATION %}{% url "account_signup" %}{% else %}{{ settings.SOCIALHOME_NODE_LIST_URL }}{% endif %}">
+                                {% trans "Sign Up" %}
+                            </a>
+                        </li>
                         <li class="nav-item">
                             <a id="log-in-link" class="nav-link" href="{% url "account_login" %}">{% trans "Log In" %}</a>
                         </li>


### PR DESCRIPTION
If signups are closed, the signup link will now stay active but will point to a list of Socialhome nodes

By default this URL is https://the-federation.info/socialhome, but can be configured by the server admin.

Closes #354