### PR TITLE
Fixes for federation changes

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -306,7 +306,7 @@ SOCIALHOME_URL = "{protocol}://{domain}".format(
     domain=SOCIALHOME_DOMAIN
 )
 # Relay to send public content to
-SOCIALHOME_RELAY_DOMAIN = env("SOCIALHOME_RELAY_DOMAIN", default="relay.iliketoast.net")
+SOCIALHOME_RELAY_ID = env("SOCIALHOME_RELAY_ID", default="diaspora://relay@relay.iliketoast.net/profile/")
 # Statistics
 # Controls whether to expose some generic statistics about the node. This includes local user, content and reply counts
 # User counts include 30 day and 6 month active users

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,8 @@ Changed
 
   No action needed from server admins unless you have changed this setting, in which case it should be updated accordingly.
 
+* Start sending profile changes to remote nodes as public messages for better efficiency
+
 0.7.0 (2018-02-04)
 ------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,13 @@ Added
 
   This allows better profile discovery by remote non-Socialhome servers.
 
+Changed
+.......
+
+* Setting ``SOCIALHOME_RELAY_DOMAIN`` is now called ``SOCIALHOME_RELAY_ID``. We're slowly replacing all direct Diaspora handle references with Diaspora URI format profile ID's in preparation for ActivityPub protocol addition.
+
+  No action needed from server admins unless you have changed this setting, in which case it should be updated accordingly.
+
 0.7.0 (2018-02-04)
 ------------------
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -274,12 +274,12 @@ Default: ``https://the-federation.info/socialhome``
 
 URL to make signup link go to in the case that signups are closed.
 
-SOCIALHOME_RELAY_DOMAIN
+SOCIALHOME_RELAY_ID
 .......................
 
-Default: ``relay.iliketoast.net``
+Default: ``diaspora://relay@relay.iliketoast.net/profile/``
 
-Which relay instance to send outgoing content to. Socialhome automatically integrates with the `relay system <https://github.com/jaywink/social-relay>`_.
+Which relay instance ID to send outgoing content to. Socialhome automatically integrates with the `relay system <https://github.com/jaywink/social-relay>`_.
 
 SOCIALHOME_ROOT_PROFILE
 .......................

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -47,7 +47,7 @@ whoosh
 # - GIF upload (upstream rejected)
 -e git+https://github.com/jaywink/django-markdownx.git@f954e9a53c7299fa60f4f39262c44206ed03c131#egg=django-markdownx==2.0.21.1
 
--e git+https://github.com/jaywink/federation.git@f80211b178d340b9fac5b5700d169e68843a25e0#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@0170a12a956bdce691b4c516d0b6fdc745a77b5d#egg=federation==0.14.1.1
 
 # Own pyembed fork for some tweaks:
 # - passing additional options (TODO make PR)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@
 #    ./compile-requirements.sh
 #
 -e git+https://github.com/jaywink/django-markdownx.git@f954e9a53c7299fa60f4f39262c44206ed03c131#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jaywink/federation.git@f80211b178d340b9fac5b5700d169e68843a25e0#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@0170a12a956bdce691b4c516d0b6fdc745a77b5d#egg=federation==0.14.1.1
 -e git+https://github.com/jaywink/pyembed.git@e2b8a994cc90b61e3a4a53eb60cad676307d8244#egg=pyembed==1.3.3.1
 arrow==0.12.1
 asgi-redis==1.4.3

--- a/socialhome/federate/tasks.py
+++ b/socialhome/federate/tasks.py
@@ -62,9 +62,7 @@ def send_content(content_id):
         if settings.DEBUG:
             # Don't send in development mode
             return
-        recipients = [
-            (settings.SOCIALHOME_RELAY_DOMAIN, "diaspora"),
-        ]
+        recipients = [settings.SOCIALHOME_RELAY_ID]
         recipients.extend(_get_remote_followers(content.author))
         handle_send(entity, content.author, recipients)
     else:
@@ -171,9 +169,7 @@ def send_content_retraction(content, author_id):
         if settings.DEBUG:
             # Don't send in development mode
             return
-        recipients = [
-            (settings.SOCIALHOME_RELAY_DOMAIN, "diaspora"),
-        ]
+        recipients = [settings.SOCIALHOME_RELAY_ID]
         recipients.extend(_get_remote_followers(author))
         handle_send(entity, author, recipients)
     else:


### PR DESCRIPTION
* Make relay default recipient a diaspora URL ID
* Update federation handle_send call parameters as per library changes
* Follow change now uses the new handle_send private payload capabilities in the federation library
* Profile send now uses public delivery for better efficiency