### PR TITLE
Fix precalculated streams maintenance job

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,13 @@ Changed
 
 * Start sending profile changes to remote nodes as public messages for better efficiency
 
+Fixed
+.....
+
+* Fix precalculated streams maintenance job.
+
+  Due to mistake in regexp not all old precalculated stream items were pruned in maintenance. Now fixed which should ensure Redis memory usage does not suffer from unreasonable increase over time.
+
 0.7.0 (2018-02-04)
 ------------------
 

--- a/socialhome/streams/tasks.py
+++ b/socialhome/streams/tasks.py
@@ -8,8 +8,11 @@ from socialhome.utils import get_redis_connection
 def groom_redis_precaches():
     """Groom the Redis data for streams precaching."""
     r = get_redis_connection()
-    keys = r.keys("sh:streams:*[^:throughs]")
+    keys = r.keys("sh:streams:[a-z0-9_\-:]*")
     for key in keys:
+        if key.decode("utf-8").endswith(':throughs'):
+            # Skip throughs, we handle those separately below
+            continue
         # Make the ordered set X items length at most
         r.zremrangebyrank(key, 0, -settings.SOCIALHOME_STREAMS_PRECACHE_SIZE)
         # Remove now obsolete throughs ID's from the throughs hash


### PR DESCRIPTION
Due to mistake in regexp not all old precalculated stream items were pruned in maintenance. Now fixed which should ensure Redis memory usage does not suffer from unreasonable increase over time.