### PR TITLE
Start sending federation payloads in new format

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,10 @@ Changed
 
 * Start sending profile changes to remote nodes as public messages for better efficiency
 
+* Start sending federation payloads in new format (`federation #59 <https://github.com/jaywink/federation/issues/59>`_)
+
+  This could drop federation compatibility with some really old servers in the fediverse, but adds compatibility to for example GangGo which is now able to receive Socialhome content.
+
 Fixed
 .....
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -47,7 +47,7 @@ whoosh
 # - GIF upload (upstream rejected)
 -e git+https://github.com/jaywink/django-markdownx.git@f954e9a53c7299fa60f4f39262c44206ed03c131#egg=django-markdownx==2.0.21.1
 
--e git+https://github.com/jaywink/federation.git@aa8e8a79607f305f33baab76cb77669f27cc6861#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@c15aa14e8e0acfbb4b4598166f861290c3ac7975#egg=federation==0.14.1.1
 
 # Own pyembed fork for some tweaks:
 # - passing additional options (TODO make PR)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@
 #    ./compile-requirements.sh
 #
 -e git+https://github.com/jaywink/django-markdownx.git@f954e9a53c7299fa60f4f39262c44206ed03c131#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jaywink/federation.git@aa8e8a79607f305f33baab76cb77669f27cc6861#egg=federation==0.14.1.1
+-e git+https://github.com/jaywink/federation.git@c15aa14e8e0acfbb4b4598166f861290c3ac7975#egg=federation==0.14.1.1
 -e git+https://github.com/jaywink/pyembed.git@e2b8a994cc90b61e3a4a53eb60cad676307d8244#egg=pyembed==1.3.3.1
 arrow==0.12.1
 asgi-redis==1.4.3


### PR DESCRIPTION
This could drop federation compatibility with some really old servers in the fediverse, but adds compatibility to for example GangGo which is now able to receive Socialhome content.

Refs: jaywink/federation#59