### PR TITLE
Omit Twitter embed scripts for oembed code fetch

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -37,6 +37,10 @@ Changed
 
   This could drop federation compatibility with some really old servers in the fediverse, but adds compatibility to for example GangGo which is now able to receive Socialhome content.
 
+* Stop requesting Twitter widget script for each tweet OEmbed (`#202 <https://github.com/jaywink/socialhome/issues/202>`_)
+
+  Since Vue streams all tweets are initialized programmatically as they are rendered in the stream so we don't need to have the script tag on each oembed separately.
+
 Fixed
 .....
 

--- a/socialhome/content/previews.py
+++ b/socialhome/content/previews.py
@@ -106,7 +106,7 @@ def fetch_oembed_preview(content, urls):
         if url.startswith("https://twitter.com/"):
             # This probably has little effect since we fetch these on the backend...
             # But, DNT is always good to communicate if possible :)
-            options = {"dnt": "true"}
+            options = {"dnt": "true", "omit_script": "true"}
         try:
             oembed = PyEmbed(discoverer=OEmbedDiscoverer()).embed(url, **options)
         except (PyEmbedError, PyEmbedDiscoveryError, PyEmbedConsumerError, ValueError):

--- a/socialhome/content/tests/test_previews.py
+++ b/socialhome/content/tests/test_previews.py
@@ -26,7 +26,7 @@ class MockOpenGraph(dict):
 class TestFetchOgPreview(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
-        super(TestFetchOgPreview, cls).setUpTestData()
+        super().setUpTestData()
         cls.content = ContentFactory()
         cls.nsfw_content = ContentFactory(text="foo #nsfw")
         cls.urls = ["https://example.com"]
@@ -96,7 +96,7 @@ class TestFetchOgPreview(SocialhomeTestCase):
 class TestFetchContentPreview(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
-        super(TestFetchContentPreview, cls).setUpTestData()
+        super().setUpTestData()
         cls.content = ContentFactory()
 
     @patch("socialhome.content.previews.find_urls_in_text", return_value=[])
@@ -142,14 +142,14 @@ class TestOEmbedDiscoverer:
 class TestFetchOEmbedPreview(SocialhomeTestCase):
     @classmethod
     def setUpTestData(cls):
-        super(TestFetchOEmbedPreview, cls).setUpTestData()
+        super().setUpTestData()
         cls.content = ContentFactory()
         cls.urls = ["https://example.com"]
 
     @patch("socialhome.content.previews.PyEmbed.embed", return_value="")
     def test_adds_dnt_flag_to_twitter_oembed(self, embed):
-        result = fetch_oembed_preview(self.content, ["https://twitter.com/foobar"])
-        embed.assert_called_once_with("https://twitter.com/foobar", dnt="true")
+        fetch_oembed_preview(self.content, ["https://twitter.com/foobar"])
+        embed.assert_called_once_with("https://twitter.com/foobar", dnt="true", omit_script="true")
 
     def test_cache_not_updated_if_previous_found(self):
         OEmbedCacheFactory(url=self.urls[0])


### PR DESCRIPTION
New Vue streams init all the embeds at once, so we don't need the
script in each single oembed code. Tell Twitter not to include it.

Refs: #202