### PR TITLE
Add user profile at authentication

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -4,7 +4,6 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.views import defaults as default_views
 from django.views.i18n import javascript_catalog
-from rest_framework.authtoken.views import obtain_auth_token
 from rest_framework.routers import DefaultRouter
 from rest_framework.schemas import get_schema_view
 from rest_framework_swagger.renderers import OpenAPIRenderer, SwaggerUIRenderer
@@ -13,7 +12,7 @@ from django_js_reverse.views import urls_js
 from socialhome.content.views import ContentBookmarkletView
 from socialhome.content.viewsets import ContentViewSet
 from socialhome.viewsets import ImageUploadView
-from socialhome.views import HomeView, MarkdownXImageUploadView
+from socialhome.views import HomeView, MarkdownXImageUploadView, ObtainSocialhomeAuthToken
 from socialhome.users.viewsets import UserViewSet, ProfileViewSet
 
 js_translations = {
@@ -74,7 +73,7 @@ urlpatterns = [
     url(r"^api/image-upload/$", ImageUploadView.as_view(), name="api-image-upload"),
     url(r"^api/streams/", include("socialhome.streams.urls.api", namespace="api-streams")),
     url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    url(r"^api-token-auth/", obtain_auth_token),
+    url(r"^api-token-auth/", ObtainSocialhomeAuthToken.as_view(), name="api-token-auth"),
 
     # Preferences
     url(r"^preferences/", include("dynamic_preferences.urls")),

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,11 +31,21 @@ API authentication can happen by setting the required HTTP header as follows:
 
     Authorization: Token 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b
 
-Your client can obtain a token for the user by posting ``username`` and ``password`` as form data or JSON to the view ``/api-token-auth/``. This will return a token as follows:
+Your client can obtain a token for the user by posting ``username`` and ``password`` as form data or JSON to the view ``/api-token-auth/``. This will return a token and limited user profile informations as follows:
 
 ::
 
-    { 'token' : '9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b' }
+    {
+      "url": "http://127.0.0.1:8000/p/68f61327-1305-4354-b56c-6549d196a325/",
+      "image_url_small": "http://127.0.0.1:8000/static/images/pony50.png",
+      "guid": "68f61327-1305-4354-b56c-6549d196a325",
+      "is_local": true,
+      "handle": "user-0@127.0.0.1:8000",
+      "home_url": "http://127.0.0.1:8000/p/68f61327-1305-4354-b56c-6549d196a325/",
+      "name": "",
+      "token": "2a37e74f235b044b275141b2d4605ca900617d13",
+      "id": 1
+    }
 
 Users can also retrieve and regenerate tokens from the UI from their profile menu.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -443,6 +443,7 @@ Changed
 
 * Create and update content will now redirect to the content created or updated. Previous behaviour was user preferred landing page.
 * Delete content will now redirect back to the page where the delete was triggered from. Previous behaviour was user preferred landing page. If the content delete is triggered from the content detail page, redirect will happen to user preferred landing page as before. (`#204 <https://github.com/jaywink/socialhome/issues/204>`_)
+* ``/api-token-auth/`` endpoint now returns limited profile information in addition to token
 
 Fixed
 .....

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -41,6 +41,8 @@ Changed
 
   Since Vue streams all tweets are initialized programmatically as they are rendered in the stream so we don't need to have the script tag on each oembed separately.
 
+* ``/api-token-auth/`` endpoint now returns limited profile information in addition to token
+
 Fixed
 .....
 
@@ -443,7 +445,6 @@ Changed
 
 * Create and update content will now redirect to the content created or updated. Previous behaviour was user preferred landing page.
 * Delete content will now redirect back to the page where the delete was triggered from. Previous behaviour was user preferred landing page. If the content delete is triggered from the content detail page, redirect will happen to user preferred landing page as before. (`#204 <https://github.com/jaywink/socialhome/issues/204>`_)
-* ``/api-token-auth/`` endpoint now returns limited profile information in addition to token
 
 Fixed
 .....

--- a/socialhome/views.py
+++ b/socialhome/views.py
@@ -5,10 +5,14 @@ from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.views.generic import TemplateView
 from markdownx.views import ImageUploadView
+from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.authtoken.models import Token
+from rest_framework.response import Response
 
 from socialhome.forms import MarkdownXImageForm
 from socialhome.streams.views import FollowedStreamView, PublicStreamView
 from socialhome.users.models import Profile
+from socialhome.users.serializers import LimitedProfileSerializer
 from socialhome.users.views import ProfileDetailView, ProfileAllContentView
 
 
@@ -49,3 +53,15 @@ class MarkdownXImageUploadView(LoginRequiredMixin, ImageUploadView):
         kwargs = super().get_form_kwargs()
         kwargs.update({"user": self.request.user})
         return kwargs
+
+
+class ObtainSocialhomeAuthToken(ObtainAuthToken):
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        user = serializer.validated_data["user"]
+        token, created = Token.objects.get_or_create(user=user)
+        data = LimitedProfileSerializer(user.profile, context={"request": self.request}).data
+        data.update({"token": token.key})
+        print(data)
+        return Response(data)


### PR DESCRIPTION
`/api-token-auth/` now returns limited profile infos in addition to token:

```
{
  "guid": "eba9d938-71a2-4570-96c2-99e6e6bb232f",
  "handle": "karl_marx@127.0.0.1:8000",
  "home_url": "http:\/\/127.0.0.1:8000\/p\/eba9d938-71a2-4570-96c2-99e6e6bb232f\/",
  "id": 2,
  "image_url_small": "http:\/\/127.0.0.1:8000\/static\/images\/pony50.png",
  "is_local": true,
  "name": "",
  "url": "http:\/\/127.0.0.1:8000\/p\/eba9d938-71a2-4570-96c2-99e6e6bb232f\/",
  "token": "0ab231f9f7ab63a6f78fd9746b9bdc9926a734fd"
}
```

- [x] Tests
- [x] Update the docs to explain how to recover token

Refs: #446 