### PR TITLE
Catch errors when searching for remote profiles

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,10 @@ Fixed
 
 * Fix receiving public content from GangGo (`federation #115 <https://github.com/jaywink/federation/issues/115>`_)
 
+* Fix various errors in search for remote profiles
+
+  For example GNU Social implements webfinger but the necessary attributes we need are not present and were causing errors.
+
 0.7.0 (2018-02-04)
 ------------------
 

--- a/socialhome/search/views.py
+++ b/socialhome/search/views.py
@@ -1,3 +1,5 @@
+import xml
+
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.shortcuts import redirect
@@ -40,7 +42,11 @@ class GlobalSearchView(SearchView):
                 profile = Profile.objects.visible_for_user(request.user).get(handle=q)
             except Profile.DoesNotExist:
                 # Try a remote search
-                remote_profile = retrieve_remote_profile(q)
+                try:
+                    remote_profile = retrieve_remote_profile(q)
+                except (AttributeError, ValueError, xml.parsers.expat.ExpatError):
+                    # Catch various errors parsing the remote profile
+                    return super().get(request, *args, **kwargs)
                 if remote_profile:
                     profile = Profile.from_remote_profile(remote_profile)
             if profile:


### PR DESCRIPTION
Catch some errors thrown in federation library while searching invalid remote profiles.