### PR TITLE
Set upper limit of memory an RQ worker can take

### DIFF
--- a/config/circus.ini
+++ b/config/circus.ini
@@ -2,6 +2,12 @@
 cmd = $(circus.env.virtual_env)/bin/python manage.py rqworker
 numprocesses = $(circus.env.rqworker_num)
 copy_env = True
+# Set some upper limit for RQ processes
+# 1024*1024*256*3 == 805306368
+# RQ idling workers use approx ~230mb and they fork, we allow twice that amount for the child.
+# This is just a hard limit to protect the server from a single worker hogging endless amounts
+# of memory which has happened due to some bugs in the processes.
+rlimit_as = 805306368
 
 [watcher:uwsgi]
 cmd = $(circus.env.virtual_env)/bin/uwsgi --die-on-term $(circus.env.socialhome_home)/uwsgi.ini

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,8 @@ Changed
 
   Don't precache items into streams for users who have not been active. Controlled by the same settings as the maintenance of precached streams. Will reduce unnecessary background jobs and make Redis memory usage even more stable.
 
+* Provided Circus configuration now ensures RQ worker processes are not allowed to endlessly hog server memory. In some rare cases it has happened that normally very stable RQ worker processes have hogged several gigabytes of memory due to reasons which are still being investigated. Now Circus will end those processes automatically.
+
 Fixed
 .....
 


### PR DESCRIPTION
Use Circus to protect a worker going crazy with ram. At least
until we find out what is causing the sometimes happening
spikes in RAM usage.