### PR TITLE
Add possibility to configure Sentry for error reporting

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -360,7 +360,7 @@ if log_target not in ("file", "syslog"):
 
 LOGGING = {
     "version": 1,
-    "disable_existing_loggers": False,
+    "disable_existing_loggers": True,
     "filters": {
         "require_debug_false": {
             "()": "django.utils.log.RequireDebugFalse"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -103,3 +103,37 @@ RQ_QUEUES["default"]["USE_REDIS_CACHE"] = "default"
 VERSATILEIMAGEFIELD_SETTINGS = {
     "create_images_on_demand": False,
 }
+
+# SENTRY
+# ------
+# If you wish to configure Sentry for error reporting, first create your
+# Sentry account and then place the DSN in `.env` as `SENTRY_DSN=dsnhere`.
+if env('SENTRY_DSN', default=None):
+    import raven
+    INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
+    RAVEN_CONFIG = {
+        'dsn': env('SENTRY_DSN'),
+        'release': raven.fetch_git_sha(os.path.abspath(os.curdir)),
+        'site': SOCIALHOME_DOMAIN,
+
+    }
+    LOGGING['handlers']['sentry'] = {
+        'level': env('SENTRY_LEVEL', default='ERROR'),
+        'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+    }
+    LOGGING['loggers']['socialhome']['handlers'].append('sentry')
+    LOGGING['loggers']['federation']['handlers'].append('sentry')
+    LOGGING['root'] = {
+        'level': 'WARNING',
+        'handlers': ['sentry', log_target],
+    }
+    LOGGING['loggers']['raven'] = {
+        'level': 'DEBUG',
+        'handlers': [log_target],
+        'propagate': False,
+    }
+    LOGGING['loggers']['sentry.errors'] = {
+        'level': 'DEBUG',
+        'handlers': [log_target],
+        'propagate': False,
+    }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Changelog
 Added
 .....
 
+* Add possibility to configure Sentry for error reporting.
+
+  Adding the Sentry project DSN as ``SENTRY_DSN=foo`` to environment variables will make all error level exceptions be raised to Sentry. To change the level, define ``SENTRY_LEVEL`` with a valid Python logging module level.
+
 Changed
 .......
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -241,6 +241,20 @@ REDIS_PORT
 
 Default: ``6379``
 
+SENTRY_DSN
+..........
+
+Default: ``None``
+
+Setting a Sentry project DSN will make all error level exceptions be raised to Sentry. To change the level, see below.
+
+SENTRY_LEVEL
+............
+
+Default: ``ERROR``
+
+Logging level used for Sentry reporting (see above). Possible options: ``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``.
+
 SOCIALHOME_ADDITIONAL_APPS
 ..........................
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -34,6 +34,7 @@ Pillow
 psycopg2-binary
 python-opengraph-jaywink
 pytz
+raven
 redis
 rq
 rq-scheduler

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -89,6 +89,7 @@ python-xrd==0.1
 python3-openid==3.1.0     # via django-allauth
 pytz==2018.3
 pyzmq==17.0.0             # via circus
+raven==6.6.0
 redis==2.10.6
 requests-oauthlib==0.8.0  # via django-allauth
 requests==2.18.4          # via coreapi, django-allauth, python-opengraph-jaywink, requests-oauthlib


### PR DESCRIPTION
Adding the Sentry project DSN as ``SENTRY_DSN=foo`` to environment variables will make all error level exceptions be raised to Sentry. To change the level, define ``SENTRY_LEVEL`` with a valid Python logging module level.