### PR TITLE
Add NodeInfo2 support

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -306,6 +306,10 @@ SOCIALHOME_URL = "{protocol}://{domain}".format(
 )
 # Relay to send public content to
 SOCIALHOME_RELAY_ID = env("SOCIALHOME_RELAY_ID", default="diaspora://relay@relay.iliketoast.net/profile/")
+# Admins
+# Boolean whether to show admin contact information to users and in server metadata
+# Uses `settings.ADMINS`.
+SOCIALHOME_SHOW_ADMINS = env.bool("SOCIALHOME_SHOW_ADMINS", default=False)
 # Statistics
 # Controls whether to expose some generic statistics about the node. This includes local user, content and reply counts
 # User counts include 30 day and 6 month active users
@@ -497,5 +501,6 @@ VERSATILEIMAGEFIELD_RENDITION_KEY_SETS = {
 FEDERATION = {
     "base_url": SOCIALHOME_URL,
     "get_profile_function": "socialhome.federate.utils.generic.get_diaspora_profile_by_handle",
+    "nodeinfo2_function": "socialhome.federate.utils.generic.get_nodeinfo2_data",
     "search_path": "/search/?q=",
 }

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ Added
 
   Adding the Sentry project DSN as ``SENTRY_DSN=foo`` to environment variables will make all error level exceptions be raised to Sentry. To change the level, define ``SENTRY_LEVEL`` with a valid Python logging module level.
 
+* Add `NodeInfo2 <https://github.com/jaywink/nodeinfo2>`_ support. For organization details, admin name and email will be published if the new setting ``SOCIALHOME_SHOW_ADMINS`` is set to ``True`` (default ``False``).
+
 Changed
 .......
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -333,6 +333,13 @@ If this is set to a local username, that users profile will be shown when naviga
 
 .. _configuration-statistics:
 
+SOCIALHOME_SHOW_ADMINS
+......................
+
+Default: ``False``
+
+If set to ``True``, allows showing the server admins to users and in server metadata. The settings used are ``DJANGO_ADMIN_NAME`` and ``DJANGO_ADMIN_MAIL``.
+
 SOCIALHOME_STATISTICS
 .....................
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -51,7 +51,7 @@ whoosh
 # - GIF upload (upstream rejected)
 -e git+https://github.com/jaywink/django-markdownx.git@bd2fa9dffcbfccc62f9cef2677921537f100bbaa#egg=django-markdownx==2.0.21.1
 
--e git+https://github.com/jaywink/federation.git@2a02f866aad037495b9d56f1a6c3e44a5e04c20a#egg=federation==0.15.0.1
+-e git+https://github.com/jaywink/federation.git@435c3d6d43a81a918d572be2c2b8db0d7783a0f3#egg=federation==0.15.0.1
 
 # Own pyembed fork for some tweaks:
 # - passing additional options (TODO make PR)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,7 +5,7 @@
 #    ./compile-requirements.sh
 #
 -e git+https://github.com/jaywink/django-markdownx.git@bd2fa9dffcbfccc62f9cef2677921537f100bbaa#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jaywink/federation.git@2a02f866aad037495b9d56f1a6c3e44a5e04c20a#egg=federation==0.15.0.1
+-e git+https://github.com/jaywink/federation.git@435c3d6d43a81a918d572be2c2b8db0d7783a0f3#egg=federation==0.15.0.1
 -e git+https://github.com/jaywink/pyembed.git@6f8c1cc98d61ee3083e9803255e4b2cc90b5a0dd#egg=pyembed==1.3.3.1
 arrow==0.12.1
 asgi-redis==1.4.3


### PR DESCRIPTION
For organization details, admin name and email will be published if the new setting ``SOCIALHOME_SHOW_ADMINS`` is set to ``True`` (default ``False``).