### PR TITLE
Searching for hashtags is now possible using the global search

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,6 +46,12 @@ Added
 
   Published policy documents are shown to both authenticated and unauthenticated users via the navigation bar cogs menu.
 
+* Searching for hashtags is now possible using the global search
+
+  The global search now in addition to profile results returns also results of matching hashtags. If the search term includes the hash ('#') and matches exactly to a tag, an instant redirect will be made to the tag stream.
+
+  **Note to admins**: Once pulling this code, you should regenerate the search indexes using the command ``./manage.py rebuild_indexes``.
+
 Changed
 .......
 

--- a/socialhome/content/models.py
+++ b/socialhome/content/models.py
@@ -58,6 +58,9 @@ class Tag(models.Model):
     def __str__(self):
         return "#%s" % self.name
 
+    def get_absolute_url(self):
+        return reverse('streams:tag', kwargs={"name": self.name})
+
     def save(self, *args, **kwargs):
         """Ensure name is lower case and stripped.
 

--- a/socialhome/content/search_indexes.py
+++ b/socialhome/content/search_indexes.py
@@ -1,0 +1,16 @@
+from django.db.models import Count
+from haystack import indexes
+
+from socialhome.content.models import Tag
+
+
+class TagIndex(indexes.ModelSearchIndex, indexes.Indexable):
+    text = indexes.EdgeNgramField(document=True, use_template=True)
+
+    class Meta:
+        model = Tag
+        fields = ("name",)
+
+    def index_queryset(self, using=None):
+        """Used when the entire index for model is updated."""
+        return self.get_model().objects.annotate(content_count=Count('contents')).filter(content_count__gt=0)

--- a/socialhome/content/templates/search/indexes/content/tag_text.txt
+++ b/socialhome/content/templates/search/indexes/content/tag_text.txt
@@ -1,0 +1,1 @@
+{{ object.name }}

--- a/socialhome/content/tests/test_models.py
+++ b/socialhome/content/tests/test_models.py
@@ -478,6 +478,9 @@ class TestTagModel(SocialhomeTestCase):
         cls.tag = Tag.objects.create(name="foobar")
         cls.tag2 = Tag.objects.create(name="f"*150)
 
+    def test_get_absolute_url(self):
+        self.assertEqual(self.tag.get_absolute_url(), '/streams/tag/foobar/')
+
     def test_tag_instance_created(self):
         self.assertTrue(Tag.objects.filter(name="foobar").exists())
 

--- a/socialhome/content/tests/test_search_indexes.py
+++ b/socialhome/content/tests/test_search_indexes.py
@@ -1,0 +1,17 @@
+from socialhome.content.search_indexes import TagIndex
+from socialhome.content.tests.factories import ContentFactory
+from socialhome.tests.utils import SocialhomeTestCase
+
+
+class TestTagIndex(SocialhomeTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.content = ContentFactory(text='#foobar')
+
+    def test_index_queryset_includes_tags_with_content(self):
+        index = TagIndex()
+        self.assertEqual(
+            set(index.index_queryset()),
+            {self.content.tags.first()}
+        )

--- a/socialhome/search/templates/search/search.html
+++ b/socialhome/search/templates/search/search.html
@@ -28,19 +28,29 @@
                                     <a href="{{ result.object.get_absolute_url }}">
                                         <img class="profile-picture" src="{{ result.object.safer_image_url_small }}">
                                     </a>
+                                {% elif result.content_type == 'content.tag' %}
+                                    <a href="{{ result.object.get_absolute_url }}">
+                                        <i class="fa fa-hashtag" aria-hidden="true"></i>
+                                    </a>
                                 {% endif %}
                             </div>
                             <div class="col-8 align-self-center">
-                                {% if result.object.name %}
-                                    <a href="{{ result.object.get_absolute_url }}">{{ result.object.name }} ({{ result.object.handle }})</a>
-                                {% else %}
-                                    <a href="{{ result.object.get_absolute_url }}">{{ result.object.handle }}</a>
+                                {% if result.content_type == "users.profile" %}
+                                    {% if result.object.name %}
+                                        <a href="{{ result.object.get_absolute_url }}">{{ result.object.name }} ({{ result.object.handle }})</a>
+                                    {% else %}
+                                        <a href="{{ result.object.get_absolute_url }}">{{ result.object.handle }}</a>
+                                    {% endif %}
+                                {% elif result.content_type == 'content.tag' %}
+                                    <a href="{{ result.object.get_absolute_url }}">#{{ result.object.name }}</a>
                                 {% endif %}
                             </div>
                             <div class="col-2 align-self-center">
-                                {% if request.user.is_authenticated %}
-                                    <button class="follower-button btn btn-secondary {% if not result.object.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ result.object.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
-                                    <button class="follower-button btn btn-secondary {% if result.object.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ result.object.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                                {% if result.content_type == "users.profile" %}
+                                    {% if request.user.is_authenticated %}
+                                        <button class="follower-button btn btn-secondary {% if not result.object.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="remove_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ result.object.guid }}" title="{% trans "Unfollow" %}" aria-label="{% trans "Unfollow" %}"><i class="fa fa-minus"></i></button>
+                                        <button class="follower-button btn btn-secondary {% if result.object.id in request.user.profile.following_ids %}hidden{% endif %}" data-action="add_follower" data-profileid="{{ request.user.profile.id }}" data-target="{{ result.object.guid }}" title="{% trans "Follow" %}" aria-label="{% trans "Follow" %}"><i class="fa fa-plus"></i></button>
+                                    {% endif %}
                                 {% endif %}
                             </div>
                         </div>


### PR DESCRIPTION
The global search now in addition to profile results returns also
'results of matching hashtags. If the search term includes the hash
('#') and matches exactly to a tag, an instant redirect will be made
to the tag stream.