### PR TITLE
Django bumped to 2.0.8 to fix a security issue

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,14 @@ Changelog
 0.10.0 (unreleased)
 -------------------
 
+0.9.1 (2018-08-11)
+------------------
+
+Fixed
+.....
+
+* Django bumped to 2.0.8 to fix a `security issue <https://docs.djangoproject.com/en/2.0/releases/2.0.8/>`_. This issue did not affect Socialhome, but we're upgrading just to be sure.
+
 0.9.0 (2018-07-21)
 ------------------
 

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -2,10 +2,11 @@ codecov
 coverage
 ddt
 django-debug-toolbar
+django-debug-toolbar-user-panel
 django-querycount
 django-test-plus<1.1.0  # Some problems running pytest with 1.1.0, figure out why
 django_coverage_plugin
-django<2.0.6  # Bump after https://github.com/ierror/django-js-reverse/issues/65 fixed
+django<2.1
 factory_boy
 Faker
 flake8
@@ -26,7 +27,6 @@ Werkzeug
 # Recommonmark master has a fix for CommonMark==0.7.3 compatibility which is not released yet
 -e git+https://github.com/rtfd/recommonmark.git@c410abb565a3c4ad4de0ce204ab2fa2db8031cf1#egg=recommonmark==0.4.0
 
-# Django-debug-toolbar-user-panel fixed with Django 2.0 support
-# Use pip once PR merged and upstream releases
-# https://github.com/thread/django-debug-toolbar-user-panel/pull/3
--e git+https://github.com/jaywink/django-debug-toolbar-user-panel.git@django-2-fix#egg=django-debug-toolbar-user-panel==1.1.0.1
+# Not a direct requirement, just to match main requirements locked version
+# TODO remove once circus is bumped to work with tornado 5.0
+tornado<5

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -4,7 +4,6 @@
 #
 #    ./compile-requirements.sh
 #
--e git+https://github.com/jaywink/django-debug-toolbar-user-panel.git@django-2-fix#egg=django-debug-toolbar-user-panel==1.1.0.1
 -e git+https://github.com/rtfd/recommonmark.git@c410abb565a3c4ad4de0ce204ab2fa2db8031cf1#egg=recommonmark==0.4.0
 alabaster==0.7.11         # via sphinx
 argh==0.26.2              # via sphinx-autobuild, watchdog
@@ -18,16 +17,17 @@ click==6.7                # via pip-tools
 codecov==2.0.15
 commonmark==0.7.5
 coverage==4.5.1
-ddt==1.1.3
+ddt==1.2.0
 decorator==4.3.0          # via ipython, traitlets
 django-coverage-plugin==1.5.0
+django-debug-toolbar-user-panel==1.1.1
 django-debug-toolbar==1.9.1
 django-querycount==0.7.0
 django-test-plus==1.0.22
-django==2.0.5
+django==2.0.8
 docutils==0.14            # via sphinx
 factory-boy==2.11.1
-faker==0.8.16
+faker==0.8.17
 first==2.0.1              # via pip-tools
 flake8==3.5.0
 freezegun==0.3.10
@@ -37,49 +37,49 @@ idna==2.7                 # via requests
 imagesize==1.0.0          # via sphinx
 ipdb==0.11
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.4.0            # via ipdb
-jedi==0.12.0              # via ipython
+ipython==6.5.0            # via ipdb
+jedi==0.12.1              # via ipython
 jinja2==2.10              # via sphinx
 livereload==2.5.2         # via sphinx-autobuild
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
-more-itertools==4.2.0     # via pytest
+more-itertools==4.3.0     # via pytest
 packaging==17.1           # via sphinx
-parso==0.2.1              # via jedi
+parso==0.3.1              # via jedi
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.4        # via ipython
 pip-tools==2.0.2
-pluggy==0.6.0             # via pytest
+pluggy==0.7.1             # via pytest
 port-for==0.3.1           # via sphinx-autobuild
 prompt-toolkit==1.0.15    # via ipython
 ptyprocess==0.6.0         # via pexpect
-py==1.5.3                 # via pytest
+py==1.5.4                 # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via ipython, sphinx
 pyparsing==2.2.0          # via packaging
 pytest-blockage==0.2.0
 pytest-cov==2.5.1
-pytest-django==3.3.2
+pytest-django==3.3.3
 pytest-env==0.6.2
 pytest-profiling==1.3.0
 pytest-sugar==0.9.1
-pytest==3.6.2
+pytest==3.7.1
 python-dateutil==2.7.3    # via faker, freezegun
-pytz==2018.4              # via babel, django
-pyyaml==3.12              # via sphinx-autobuild, watchdog
+pytz==2018.5              # via babel, django
+pyyaml==3.13              # via sphinx-autobuild, watchdog
 requests==2.19.1          # via codecov, sphinx
 simplegeneric==0.8.1      # via ipython
 six==1.11.0               # via django-coverage-plugin, faker, freezegun, livereload, more-itertools, packaging, pip-tools, prompt-toolkit, pytest, pytest-profiling, python-dateutil, sphinx, traitlets
 snowballstemmer==1.2.1    # via sphinx
 sphinx-autobuild==0.7.1
-sphinx==1.7.5
+sphinx==1.7.6
 sphinxcontrib-websupport==1.1.0  # via sphinx
 sqlparse==0.2.4           # via django-debug-toolbar
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
-tornado==4.5.3            # via livereload, sphinx-autobuild
+tornado==4.5.3
 traitlets==4.3.2          # via ipython
 urllib3==1.23             # via requests
 watchdog==0.8.3           # via sphinx-autobuild

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -23,12 +23,13 @@ django-model-utils
 django-redis
 django-rest-swagger
 django-reversion
+django-robots
 django-rq
 django-secure
 django-settings-export
 django-tables2
 django-versatileimagefield
-django<2.0.6  # Bump after https://github.com/ierror/django-js-reverse/issues/65 fixed
+django<2.1
 djangorestframework
 ipython
 lxml
@@ -58,7 +59,3 @@ whoosh
 # - requests timeout (TODO make PR)
 # - decrease consumer error logging level to debug (TODO make PR)
 -e git+https://github.com/jaywink/pyembed.git@6f8c1cc98d61ee3083e9803255e4b2cc90b5a0dd#egg=pyembed==1.3.3.1
-
-# Django-Robots - waiting for pypi release of 3.1.0
-# See https://github.com/jazzband/django-robots/issues/87
--e git+https://github.com/jazzband/django-robots.git@3.1.0#egg=robots

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -5,18 +5,17 @@
 #    ./compile-requirements.sh
 #
 -e git+https://github.com/jaywink/django-markdownx.git@bd2fa9dffcbfccc62f9cef2677921537f100bbaa#egg=django-markdownx==2.0.21.1
--e git+https://github.com/jazzband/django-robots.git@3.1.0#egg=robots
 -e git+https://github.com/jaywink/federation.git@bfb4792f16167488e8e69a44e1cacba8183a8268#egg=federation==0.15.0.1
 -e git+https://github.com/jaywink/pyembed.git@6f8c1cc98d61ee3083e9803255e4b2cc90b5a0dd#egg=pyembed==1.3.3.1
 arrow==0.12.1
 asgi-redis==1.4.3
 asgiref==1.1.2            # via asgi-redis, channels, daphne
-attrs==18.1.0             # via automat
-autobahn==18.6.1          # via daphne
+attrs==18.1.0             # via automat, twisted
+autobahn==18.7.1          # via daphne
 automat==0.7.0            # via twisted
 backcall==0.1.0           # via ipython
 backports-abc==0.5
-beautifulsoup4==4.6.0
+beautifulsoup4==4.6.1
 bleach==2.1.3
 certifi==2018.4.16        # via requests
 channels==1.1.8
@@ -27,7 +26,7 @@ commonmark==0.7.5
 constantly==15.1.0        # via twisted
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-croniter==0.3.24          # via rq-scheduler
+croniter==0.3.25          # via rq-scheduler
 cssselect==1.0.3
 daphne==1.4.2             # via channels
 decorator==4.3.0          # via ipython, traitlets
@@ -39,23 +38,24 @@ django-braces==1.13.0
 django-crispy-forms==1.7.2
 django-dynamic-preferences==1.5.1
 django-enumfields==0.10.1
-django-environ==0.4.4
-django-extensions==2.0.7
+django-environ==0.4.5
+django-extensions==2.1.0
 django-floppyforms==1.7.0
 django-fsm==2.6.0
 django-haystack==2.8.1
-django-js-reverse==0.8.1
+django-js-reverse==0.8.2
 django-memoize==2.1.1
 django-model-utils==3.1.2
 django-redis==4.9.0
 django-rest-swagger==2.2.0
-django-reversion==2.0.13
-django-rq==1.1.0
+django-reversion==3.0.0
+django-robots==3.1.0
+django-rq==1.2.0
 django-secure==1.0.1
 django-settings-export==1.2.1
 django-tables2==1.21.2
 django-versatileimagefield==1.9
-django==2.0.5
+django==2.0.8
 djangorestframework==3.8.2
 future==0.16.0            # via commonmark
 html5lib==1.0.1           # via bleach
@@ -64,19 +64,19 @@ idna==2.7                 # via hyperlink, requests
 incremental==17.5.0       # via twisted
 ipdata==2.6
 ipython-genutils==0.2.0   # via traitlets
-ipython==6.4.0
+ipython==6.5.0
 isodate==0.6.0            # via python-xrd
 itypes==1.1.0             # via coreapi
-jedi==0.12.0              # via ipython
+jedi==0.12.1              # via ipython
 jinja2==2.10              # via coreschema
 jsonschema==2.6.0
-lxml==4.2.2
+lxml==4.2.4
 markdown==2.6.11
 markupsafe==1.0           # via jinja2
 msgpack-python==0.5.6     # via asgi-redis
 oauthlib==2.1.0           # via requests-oauthlib
 openapi-codec==1.3.2      # via django-rest-swagger
-parso==0.2.1              # via jedi
+parso==0.3.1              # via jedi
 persisting-theory==0.2.1  # via django-dynamic-preferences
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.4        # via ipython
@@ -87,33 +87,34 @@ psycopg2-binary==2.7.5
 ptyprocess==0.6.0         # via pexpect
 pycrypto==2.6.1
 pygments==2.2.0           # via ipython
+pyhamcrest==1.9.0         # via twisted
 python-dateutil==2.7.3    # via arrow, croniter
 python-opengraph-jaywink==0.2.0
 python-xrd==0.1
 python3-openid==3.1.0     # via django-allauth
-pytz==2018.4
+pytz==2018.5
 pyzmq==16.0.4             # via circus
 raven==6.9.0
 redis==2.10.6
 requests-oauthlib==1.0.0  # via django-allauth
 requests==2.19.1          # via coreapi, django-allauth, python-opengraph-jaywink, requests-oauthlib
 rq-scheduler==0.8.3
-rq==0.11.0
+rq==0.12.0
 simplegeneric==0.8.1      # via ipython
-simplejson==3.15.0        # via django-rest-swagger
-six==1.11.0               # via asgi-redis, asgiref, autobahn, automat, bleach, circus, django-dynamic-preferences, django-environ, django-extensions, html5lib, isodate, prompt-toolkit, python-dateutil, traitlets, txaio, unicode-slugify
+simplejson==3.16.0        # via django-rest-swagger
+six==1.11.0               # via asgi-redis, asgiref, autobahn, automat, bleach, circus, django-dynamic-preferences, django-extensions, html5lib, isodate, prompt-toolkit, pyhamcrest, python-dateutil, traitlets, txaio, unicode-slugify
 tornado==4.5.3            # via circus
 traitlets==4.3.2          # via ipython
-twisted==18.4.0           # via daphne
-txaio==2.10.0             # via autobahn
+twisted==18.7.0           # via daphne
+txaio==18.7.1             # via autobahn
 typing==3.6.4
 unicode-slugify==0.1.3
 unidecode==1.0.22         # via unicode-slugify
 uritemplate==3.0.0        # via coreapi
 urllib3==1.23             # via requests
-uwsgi==2.0.17
+uwsgi==2.0.17.1
 wcwidth==0.1.7            # via prompt-toolkit
 webencodings==0.5.1       # via html5lib
-whitenoise==3.3.1
+whitenoise==4.0
 whoosh==2.7.4
 zope.interface==4.5.0     # via twisted

--- a/socialhome/__init__.py
+++ b/socialhome/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.9.1"
+__version__ = "0.10.0-dev"
 __version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace("-", ".", 1).split(".")])
 
 default_app_config = "socialhome.apps.SocialhomeConfig"

--- a/socialhome/__init__.py
+++ b/socialhome/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "0.10.0-dev"
+__version__ = "0.9.1"
 __version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace("-", ".", 1).split(".")])
 
 default_app_config = "socialhome.apps.SocialhomeConfig"


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.0/releases/2.0.8/

This issue did not affect Socialhome, but we're upgrading just to be sure.

Also other Python version updates.