### PR TITLE
Api ui fix

### DIFF
--- a/config/tests/test_urls.py
+++ b/config/tests/test_urls.py
@@ -1,0 +1,7 @@
+from socialhome.tests.utils import SocialhomeTestCase
+
+
+class TestSchemaView(SocialhomeTestCase):
+    def test_page_renders(self):
+        response = self.client.get("/api/")
+        self.assertEqual(response.status_code, 200)

--- a/socialhome/templates/rest_framework_swagger/index.html
+++ b/socialhome/templates/rest_framework_swagger/index.html
@@ -18,10 +18,9 @@
     <div class="topbar">
       <div class="wrapper">
         <div class="topbar-wrapper">
-          <a href="#" class="link">
-            <img src="{% static 'rest_framework_swagger/logo_small.png' %}" alt="Swagger Logo">
-            <span>swagger</span>
-          </a>
+          <div class="input" style="float: left; margin-top: 5px;">
+            <a href="/" class="header__btn">{{ request.site.name }}</a>
+          </div>
           <div class="download-url-wrapper">
           {% if USE_SESSION_AUTH %}
             {% if request.user.is_authenticated %}

--- a/socialhome/templates/rest_framework_swagger/index.html
+++ b/socialhome/templates/rest_framework_swagger/index.html
@@ -1,7 +1,70 @@
-{% extends "rest_framework_swagger/base.html" %}
+{% load i18n %}
+{% load staticfiles %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Socialhome API</title>
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
+  <link href="{% static 'rest_framework_swagger/bundles/vendors.bundle.css' %}" rel="stylesheet" type="text/css">
+  <link href="{% static 'rest_framework_swagger/bundles/app.bundle.css' %}" rel="stylesheet" type="text/css">
+  {% block extra_styles %}
+  {# -- Add any additional CSS scripts here -- #}
+  {% endblock %}
+</head>
 
-{% block logo %}
-    <div class="input" style="float: left; margin-top: 5px;">
-        <a class="header__btn" href="/">{{ request.site.name }}</a>
+<body>
+  <div class="swagger-ui">
+    <div class="topbar">
+      <div class="wrapper">
+        <div class="topbar-wrapper">
+          <a href="#" class="link">
+            <img src="{% static 'rest_framework_swagger/logo_small.png' %}" alt="Swagger Logo">
+            <span>swagger</span>
+          </a>
+          <div class="download-url-wrapper">
+          {% if USE_SESSION_AUTH %}
+            {% if request.user.is_authenticated %}
+            <a class="download-url-button button" href="{{ LOGOUT_URL }}?next={{ request.path }}">{% trans "Logout" %}</a>
+            {% else %}
+            <a class="download-url-button button" href="{{ LOGIN_URL }}?next={{ request.path }}">{% trans "Session Login" %}</a>
+            {% endif %}
+          {% endif %}
+          </div>
+        </div>
+      </div>
     </div>
-{% endblock %}
+    {% if USE_SESSION_AUTH %}
+    <div class="user-context wrapper">
+      {% block user_context_message %}
+        {% if request.user.is_authenticated %}
+          {% trans "You are logged in as: " %}<strong>{{ request.user }}</strong>
+        {% else %}
+           {% trans "Viewing as an anoymous user" %}
+       {% endif %}
+      {% endblock %}
+    </div>
+    {% endif %}
+  </div>
+
+  <div id="rest-swagger-ui"></div>
+  {% csrf_token %}
+
+  <footer class="swagger-ui">
+    <div class="wrapper">
+      {% trans "Powered by "%}<a href="https://github.com/marcgibbons/django-rest-swagger" target="_new">Django REST Swagger</a>
+    </div>
+  </footer>
+
+  <script>
+    window.drsSettings = {{ drs_settings|safe }};
+    window.drsSpec = {{ spec|safe }};
+  </script>
+  <script src="{% static 'rest_framework_swagger/bundles/vendors.bundle.js' %}"></script>
+  <script src="{% static 'rest_framework_swagger/bundles/app.bundle.js' %}"></script>
+  {% block extra_scripts %}
+  {# -- Add any additional scripts here -- #}
+  {% endblock %}
+</body>
+
+</html>

--- a/socialhome/tests/test_api_docs.py
+++ b/socialhome/tests/test_api_docs.py
@@ -3,5 +3,5 @@ from socialhome.tests.utils import SocialhomeTestCase
 
 class TestSchemaView(SocialhomeTestCase):
     def test_page_renders(self):
-        response = self.client.get("/api/")
-        self.assertEqual(response.status_code, 200)
+        self.get("api-docs")
+        self.response_200()


### PR DESCRIPTION
Fixes #509 and keeps customization which was in place for the API browsable endpoint. Now `rest_framework_swagger/index.html` is overwritten directly, instead of extending (the no-longer-existent) `rest_framework_swagger/base.html`. This change was necessary because of a change in Swagger v 2.2.0. 
Also adds a very simple test which checks that the browsable endpoint `/api/` responds successfully. I put this in `config/tests/test_urls.py` (a new file) because `config/urls.py` is where Swagger is told to produce the API docs-- if there's a better place to put the test, let me know.