### PR TITLE
Fix issue 518: Don't fail with internal server error for user pages

### DIFF
--- a/socialhome/users/tests/test_views.py
+++ b/socialhome/users/tests/test_views.py
@@ -240,6 +240,11 @@ class TestOrganizeContentUserDetailView(SocialhomeTestCase):
         request, view, contents, profile = self._get_request_view_and_content()
         assert view.get_success_url() == "/u/%s/" % profile.user.username
 
+    def test_login_required(self):
+        self.user = AnonymousUser()
+        response = self.get('users:profile-organize')
+        assert response.status_code == 302
+
 
 @pytest.mark.usefixtures("admin_user", "client")
 class TestProfileVisibilityForAnonymous:

--- a/socialhome/users/tests/test_views.py
+++ b/socialhome/users/tests/test_views.py
@@ -503,6 +503,11 @@ class TestUserAPITokenView(SocialhomeTestCase):
         new_token = Token.objects.get(user=self.user)
         self.assertNotEqual(new_token.key, old_token.key)
 
+    def test_login_required(self):
+        self.user = AnonymousUser()
+        response = self.get('users:api-token')
+        assert response.status_code == 302
+
 
 class TestUserPictureUpdateView(SocialhomeTestCase):
     @classmethod

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -176,10 +176,6 @@ class UserPictureUpdateView(LoginRequiredMixin, UpdateView):
 class UserAPITokenView(LoginRequiredMixin, TemplateView):
     template_name = "users/user_api_token.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        return super().dispatch(request, *args, **kwargs)
-
     def get_object(self, queryset=None):
         return User.objects.get(id=self.request.user.id)
 
@@ -193,7 +189,7 @@ class UserAPITokenView(LoginRequiredMixin, TemplateView):
 
     def post(self, request, *args, **kwargs):
         if request.POST.get("regenerate") == "regenerate":
-            self.object.auth_token.delete()
+            self.get_object().auth_token.delete()
         return redirect(self.get_success_url())
 
 

--- a/socialhome/users/views.py
+++ b/socialhome/users/views.py
@@ -128,13 +128,9 @@ class OrganizeContentProfileDetailView(LoginRequiredMixin, ListView):
     model = Content
     template_name = "users/profile_detail_organize.html"
 
-    def dispatch(self, request, *args, **kwargs):
-        """Use current user."""
-        self.profile = get_object_or_404(Profile, user=self.request.user)
-        return super().dispatch(request, *args, **kwargs)
-
     def get_queryset(self):
-        return Content.objects.profile_pinned(self.profile, self.request.user).order_by("order")
+        profile = get_object_or_404(Profile, user=self.request.user)
+        return Content.objects.profile_pinned(profile, self.request.user).order_by("order")
 
     def post(self, request, *args, **kwargs):
         """Save sort order."""


### PR DESCRIPTION
Changed behaviour of 2 views to redirect unauthorized users to login page instead of failing with internal error.